### PR TITLE
Fix export creation for sales celebration

### DIFF
--- a/shared/webhook-service.js
+++ b/shared/webhook-service.js
@@ -417,13 +417,14 @@ class WebhookService {
             optimizeForDigitalSignage: true
           };
           
-          contentExportId = await this.contentService.generateProjectExport(
+          const exportInfo = await this.contentService.generateProjectExport(
             contentProject.id,
             webhookEndpoint.tenantId,
             exportOptions
           );
-          
-          console.log('📦 Generated content export:', contentExportId);
+          contentExportId = exportInfo.exportId;
+
+          console.log('📦 Generated content export:', exportInfo.publicUrl);
           
           // Publish to OptiSigns
           const publishResult = await this.contentService.publishToOptiSigns(


### PR DESCRIPTION
## Summary
- update `generateProjectExport` to create a `ContentExport` record with a public URL
- return new export information from export creation
- update webhook service to handle new return data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861beee5ce08331840196e87ab2bb84