### PR TITLE
Fix SMS services

### DIFF
--- a/shared/twilio-service.js
+++ b/shared/twilio-service.js
@@ -67,7 +67,7 @@ async sendSms(tenantId, options) {
       const fromNumber = from || await this.selectFromNumber(tenantId, to);
 
       // Create SMS record
-      const smsRecord = await this.models.SmsMessage.create({
+      smsRecord = await this.models.SmsMessage.create({
         tenantId,
         leadId,
         from: fromNumber,
@@ -535,7 +535,7 @@ async sendSms(tenantId, options) {
   async updateFromNumberUsage(phoneNumber) {
     await this.models.SmsPhoneNumber.update(
       {
-        usageCount: this.sequelize.literal('usage_count + 1'),
+        usageCount: this.models.sequelize.literal('usage_count + 1'),
         lastUsed: new Date()
       },
       {
@@ -690,7 +690,7 @@ async sendSms(tenantId, options) {
     // Update template usage count
     await this.models.Template.update(
       {
-        usageCount: this.sequelize.literal('usage_count + 1'),
+        usageCount: this.models.sequelize.literal('usage_count + 1'),
         lastUsed: new Date()
       },
       {
@@ -760,6 +760,13 @@ async sendSms(tenantId, options) {
       console.error('Error syncing Twilio numbers:', error);
       throw error;
     }
+  }
+
+  /**
+   * Invalidate cached client
+   */
+  invalidateClient(tenantId) {
+    this.clients.delete(tenantId);
   }
 }
 

--- a/worker/sms-service.js
+++ b/worker/sms-service.js
@@ -6,23 +6,16 @@ class SmsService {
    * @param {Object} tenant - The tenant object with SMS configuration
    * @param {Object} models - Object containing Sequelize models { SmsLog, Lead }
    */
-  constructor(tenant, models) {
+  constructor(tenant, models = {}) {
     this.tenant = tenant;
     this.models = models;
     this.twilioClient = null;
-    
-    if (tenant.smsConfig && tenant.smsConfig.twilioAccountSid && tenant.smsConfig.twilioAuthToken) {
-      this.twilioClient = twilio(
-        tenant.smsConfig.twilioAccountSid,
-        tenant.smsConfig.twilioAuthToken
-      );
-    }
-  }
-  constructor(tenant) {
-    this.tenant = tenant;
-    this.twilioClient = null;
-    
-    if (tenant.smsConfig && tenant.smsConfig.twilioAccountSid && tenant.smsConfig.twilioAuthToken) {
+
+    if (
+      tenant.smsConfig &&
+      tenant.smsConfig.twilioAccountSid &&
+      tenant.smsConfig.twilioAuthToken
+    ) {
       this.twilioClient = twilio(
         tenant.smsConfig.twilioAccountSid,
         tenant.smsConfig.twilioAuthToken
@@ -37,7 +30,7 @@ class SmsService {
     
     try {
       // Create SMS log entry
-      const smsLog = await SmsLog.create({
+      const smsLog = await this.models.SmsLog.create({
         tenantId: this.tenant.id.toString(),
         leadId: lead.id,
         from: this.tenant.smsConfig.twilioPhoneNumber,


### PR DESCRIPTION
## Summary
- fix Twilio SMS record creation bug
- update usage tracking to reference sequelize instance
- add cached client invalidation
- clean up worker SMS service

## Testing
- `node e2e-test.js` *(fails: Server not responding)*

------
https://chatgpt.com/codex/tasks/task_e_6861c42ff340833192762547a438427c