### PR TITLE
Add API docs for content creator and OptiSigns

### DIFF
--- a/docs/content-creator-api.md
+++ b/docs/content-creator-api.md
@@ -1,0 +1,60 @@
+# Content Creator API
+
+This document describes the HTTP endpoints exposed by the Content Creation service. All authenticated routes require a valid JWT via the `Authorization: Bearer <token>` header.
+
+## Public OptiSync Endpoints
+These endpoints are primarily used by OptiSigns to pull content from the system.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/content/optisync/projects/:projectId/feed` | Generate OptiSync data feed for a project. |
+| `GET` | `/api/content/optisync/projects` | List projects available for OptiSync. |
+| `POST` | `/api/content/optisync/projects/:projectId/webhook` | Notify the system of updates. |
+| `GET` | `/api/content/public/:exportId` | Serve exported content for anonymous access. |
+| `GET` | `/api/content/optisync/status` | Check OptiSync integration status. |
+
+## Template Endpoints
+Manage templates for reusable layouts.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/content/templates` | List templates with optional filters. |
+| `GET` | `/api/content/templates/:templateId` | Retrieve a single template. |
+| `POST` | `/api/content/templates` | Create a new template. |
+
+## Project Endpoints
+Projects contain elements that make up a piece of content.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/content/projects` | List projects with filters. |
+| `POST` | `/api/content/projects` | Create a new project. |
+| `GET` | `/api/content/projects/:projectId` | Retrieve a project including elements. |
+| `PUT` | `/api/content/projects/:projectId` | Update a project. |
+| `DELETE` | `/api/content/projects/:projectId` | Remove a project. |
+| `POST` | `/api/content/projects/:projectId/elements` | Add an element to a project. |
+| `PUT` | `/api/content/projects/:projectId/elements/:elementId` | Update an element. |
+| `DELETE` | `/api/content/projects/:projectId/elements/:elementId` | Delete an element. |
+| `PUT` | `/api/content/projects/:projectId/elements/reorder` | Reorder elements inside a project. |
+
+## Asset Endpoints
+Upload and manage assets used by elements.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/content/assets` | List uploaded assets. |
+| `POST` | `/api/content/assets/upload` | Upload a new asset file. |
+| `DELETE` | `/api/content/assets/:assetId` | Remove an asset. |
+
+## Variables and Exporting
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/content/variables` | List user variables. |
+| `POST` | `/api/content/variables` | Create or update a variable. |
+| `POST` | `/api/content/variables/initialize-system` | Create built‑in variables for a new tenant. |
+| `POST` | `/api/content/projects/:projectId/preview` | Generate a preview HTML page. |
+| `POST` | `/api/content/projects/:projectId/publish` | Export a project and make it public. |
+| `GET` | `/api/content/exports/:exportId/status` | Check export processing status. |
+| `GET` | `/api/content/system/status` | Service health check. |
+

--- a/docs/optisigns-service-api.md
+++ b/docs/optisigns-service-api.md
@@ -1,0 +1,35 @@
+# OptiSigns Service API
+
+These endpoints integrate with the OptiSigns digital signage platform. All routes require authentication and assume the tenant has configured an OptiSigns API token.
+
+## Configuration
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `PUT` | `/optisigns/config` | Store or update the API token and settings. |
+| `GET` | `/optisigns/config` | Retrieve current configuration. |
+| `POST` | `/optisigns/config/test` | Verify that a provided token is valid. |
+| `GET` | `/optisigns/status` | Check connection status and statistics. |
+
+## Displays
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/optisigns/displays/sync` | Synchronize displays from OptiSigns. |
+| `GET` | `/optisigns/displays` | List displays stored locally. |
+| `GET` | `/optisigns/displays/:id` | Get a single display and recent events. |
+| `PUT` | `/optisigns/displays/:id` | Update a display in OptiSigns and locally. |
+| `POST` | `/optisigns/displays/:id/tags` | Add tags to a display. |
+| `DELETE` | `/optisigns/displays/:id/tags` | Remove tags from a display. |
+| `POST` | `/optisigns/displays/:id/takeover` | Temporarily override a display. |
+| `POST` | `/optisigns/displays/:id/stop-takeover` | Stop the takeover. |
+| `GET` | `/optisigns/displays/:id/takeover-status` | Check takeover status. |
+| `GET` | `/optisigns/takeovers` | List active takeovers. |
+| `POST` | `/optisigns/displays/:id/push` | Push content to a display. |
+
+## Assets
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/optisigns/assets/upload` | Upload a file asset. |
+| `POST` | `/optisigns/assets/website` | Create a website asset. |
+| `POST` | `/optisigns/assets/sync` | Synchronize assets from OptiSigns. |
+| `GET` | `/optisigns/assets` | List assets stored locally. |
+


### PR DESCRIPTION
## Summary
- document endpoints for the content creation service
- document endpoints for the OptiSigns integration

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861e091dbb48331acdb44f15caf72e8