### PR TITLE
Add reporting API documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -141,8 +141,102 @@ Base path: `/api/optisigns`
 | ------ | -------- | ----------- |
 | `POST` | `/displays/:id/push` | Push content to a display immediately or by schedule. |
 
+## Reporting Service API
+
+Base path: `/api`
+
+### Dashboard
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/dashboard/live-stats` | Get real-time dashboard statistics. |
+| `GET` | `/dashboard/historical` | Retrieve historical dashboard data. |
+| `GET` | `/dashboard/config` | Get dashboard configuration. |
+| `POST` | `/dashboard/config` | Save dashboard configuration. |
+
+### Lead Filters
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/lead-sources` | List available lead sources. |
+| `GET` | `/lead-tags` | List available lead tags. |
+
+### Lead Reports
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/reports/lead-source-performance` | Generate a lead source performance report. |
+| `POST` | `/reports/lead-source-comparison` | Compare multiple lead sources. |
+| `POST` | `/reports/lead-trends` | Get lead trends over time. |
+| `POST` | `/reports/lead-source-performance/export` | Export the lead source performance report. |
+| `GET`  | `/reports/lead-source/:source/performance` | Performance metrics for a single lead source. |
+| `GET`  | `/metrics/lead-summary` | Quick lead metrics summary. |
+| `GET`  | `/metrics/real-time-leads` | Real-time lead metrics. |
+
+### Journey Reports
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/reports/journey-overview` | Generate a journey overview report. |
+| `GET`  | `/reports/journey-funnel/:journeyId` | Journey funnel data. |
+| `POST` | `/reports/journey-compare` | Compare multiple journeys. |
+| `POST` | `/reports/journey-analytics` | Journey analytics report. |
+
+### Lead Generation
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/reports/lead-gen/sources` | Lead generation source report. |
+| `POST` | `/reports/lead-gen/quality` | Lead quality report. |
+| `POST` | `/reports/lead-gen/funnel` | Lead conversion funnel report. |
+
+### Standard Reports
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/reports/call-summary` | Generate call summary report. |
+| `POST` | `/reports/sms-summary` | Generate SMS summary report. |
+| `POST` | `/reports/agent-performance` | Agent performance report. |
+| `POST` | `/reports/lead-conversion` | Lead conversion report. |
+| `POST` | `/reports/custom` | Execute custom report (admin only). |
+| `POST` | `/reports/export` | Export report data. |
+
+### Report Templates
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/report-templates` | List report templates. |
+| `GET` | `/report-templates/:id` | Retrieve report template. |
+| `POST` | `/report-templates` | Create report template. |
+| `PUT` | `/report-templates/:id` | Update report template. |
+| `DELETE` | `/report-templates/:id` | Delete report template. |
+
+### Quick Stats
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/stats/today` | Get today's aggregated stats. |
+| `GET` | `/stats/hourly` | Hourly stats for today. |
+
+## Report Builder API
+
+Base path: `/api`
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/report-builders` | List report builders. |
+| `GET` | `/report-builders/:id` | Retrieve a report builder configuration. |
+| `POST` | `/report-builders` | Create a report builder. |
+| `PUT` | `/report-builders/:id` | Update a report builder. |
+| `DELETE` | `/report-builders/:id` | Delete a report builder. |
+| `POST` | `/report-builders/:id/widgets` | Add a widget to a report builder. |
+| `POST` | `/report-builders/:id/widgets/reorder` | Reorder widgets within a builder. |
+| `PUT` | `/widgets/:id` | Update a report widget. |
+| `DELETE` | `/widgets/:id` | Delete a report widget. |
+| `GET` | `/public/report-builders/:token` | Access a report builder using a public token. |
+
 ---
 
-These APIs are defined in `shared/content-creation-routes.js` and `shared/optisigns-routes.js` and are initialized by the server. Refer to the source for implementation specifics.
+These APIs are defined in `shared/content-creation-routes.js`, `shared/optisigns-routes.js`, `shared/reporting-routes.js` and `shared/report-builder-routes.js` and are initialized by the server. Refer to the source for implementation specifics.
 
 


### PR DESCRIPTION
## Summary
- document reporting service endpoints
- explain report builder API
- update API docs footer with new route files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861e2db08088331b4d8a60aa7c47fe2