### PR TITLE
Improve asset thumbnails and unify template API

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -29,6 +29,8 @@ console.log('✅ Static file serving enabled for /uploads');
 app.use('/uploads/content/thumbnails', express.static(path.join(__dirname, 'uploads/content/thumbnails')));
 app.use('/uploads/content/previews', express.static(path.join(__dirname, 'uploads/content/previews')));
 app.use('/uploads/content/assets', express.static(path.join(__dirname, 'uploads/content/assets')));
+app.use('/uploads/content/sales-rep-thumbnails', express.static(path.join(__dirname, 'uploads/content/sales-rep-thumbnails')));
+app.use('/uploads/content/sales-rep-previews', express.static(path.join(__dirname, 'uploads/content/sales-rep-previews')));
 console.log('✅ Content creation static file serving configured');
 
 
@@ -962,7 +964,7 @@ try {
   // Initialize template module
   try {
     const initTemplates = require('../shared/template-routes');
-    templateModels = initTemplates(app, sequelize, authenticateToken);
+    templateModels = initTemplates(app, sequelize, authenticateToken, contentService);
     console.log('Template module initialized successfully');
   } catch (error) {
     console.error('Error initializing template module:', error);

--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -37,8 +37,13 @@ class ContentCreationService {
       temp: path.join(this.uploadPath, 'temp'),
       optimized: path.join(this.uploadPath, 'optimized'),
       downloaded: path.join(this.uploadPath, 'downloaded'), // for downloaded external images
-      videos: path.join(this.uploadPath, 'videos') // generated announcement videos
+      videos: path.join(this.uploadPath, 'videos'), // generated announcement videos
+      salesRepThumbnails: path.join(this.uploadPath, 'sales-rep-thumbnails'),
+      salesRepPreviews: path.join(this.uploadPath, 'sales-rep-previews')
     };
+
+    // Ensure all directories exist on initialization
+    this.ensureUploadDirectories();
     
     // Element type categorization
     this.elementCategories = {

--- a/shared/sales-rep-photo-routes.js
+++ b/shared/sales-rep-photo-routes.js
@@ -101,6 +101,63 @@ module.exports = function(app, sequelize, authenticateToken, contentService) {
         metadata
       );
 
+      try {
+        const thumbName = path.basename(asset.thumbnailUrl || '');
+        const repThumbDir = contentService.directories.salesRepThumbnails;
+        const repPreviewDir = contentService.directories.salesRepPreviews;
+        await fs.mkdir(repThumbDir, { recursive: true });
+        await fs.mkdir(repPreviewDir, { recursive: true });
+
+        if (thumbName) {
+          const src = path.join(contentService.directories.thumbnails, thumbName);
+          const dest = path.join(repThumbDir, thumbName);
+          await fs.copyFile(src, dest);
+          asset.thumbnailUrl = `${req.protocol}://${req.get('host')}/uploads/content/sales-rep-thumbnails/${thumbName}`;
+        }
+
+        const newPreviews = {};
+        for (const [size, url] of Object.entries(asset.previewUrls || {})) {
+          const name = path.basename(url);
+          const src = path.join(contentService.directories.previews, name);
+          const dest = path.join(repPreviewDir, name);
+          await fs.copyFile(src, dest);
+          newPreviews[size] = `${req.protocol}://${req.get('host')}/uploads/content/sales-rep-previews/${name}`;
+        }
+
+        await asset.update({ thumbnailUrl: asset.thumbnailUrl, previewUrls: newPreviews });
+      } catch (thumbErr) {
+        console.warn('⚠️ Failed to persist sales rep thumbnails:', thumbErr.message);
+      }
+
+      // Persist thumbnails/previews in dedicated sales rep folders
+      try {
+        const thumbName = path.basename(asset.thumbnailUrl || '');
+        const repThumbDir = contentService.directories.salesRepThumbnails;
+        const repPreviewDir = contentService.directories.salesRepPreviews;
+        await fs.mkdir(repThumbDir, { recursive: true });
+        await fs.mkdir(repPreviewDir, { recursive: true });
+
+        if (thumbName) {
+          const src = path.join(contentService.directories.thumbnails, thumbName);
+          const dest = path.join(repThumbDir, thumbName);
+          await fs.copyFile(src, dest);
+          asset.thumbnailUrl = `${req.protocol}://${req.get('host')}/uploads/content/sales-rep-thumbnails/${thumbName}`;
+        }
+
+        const newPreviews = {};
+        for (const [size, url] of Object.entries(asset.previewUrls || {})) {
+          const name = path.basename(url);
+          const src = path.join(contentService.directories.previews, name);
+          const dest = path.join(repPreviewDir, name);
+          await fs.copyFile(src, dest);
+          newPreviews[size] = `${req.protocol}://${req.get('host')}/uploads/content/sales-rep-previews/${name}`;
+        }
+
+        await asset.update({ thumbnailUrl: asset.thumbnailUrl, previewUrls: newPreviews });
+      } catch (thumbErr) {
+        console.warn('⚠️ Failed to persist sales rep thumbnails:', thumbErr.message);
+      }
+
       console.log('✅ Asset uploaded with thumbnails:', {
         id: asset.id,
         thumbnailUrl: asset.thumbnailUrl,
@@ -173,6 +230,34 @@ module.exports = function(app, sequelize, authenticateToken, contentService) {
             file,
             metadata
           );
+
+          try {
+            const thumbName = path.basename(asset.thumbnailUrl || '');
+            const repThumbDir = contentService.directories.salesRepThumbnails;
+            const repPreviewDir = contentService.directories.salesRepPreviews;
+            await fs.mkdir(repThumbDir, { recursive: true });
+            await fs.mkdir(repPreviewDir, { recursive: true });
+
+            if (thumbName) {
+              const src = path.join(contentService.directories.thumbnails, thumbName);
+              const dest = path.join(repThumbDir, thumbName);
+              await fs.copyFile(src, dest);
+              asset.thumbnailUrl = `${req.protocol}://${req.get('host')}/uploads/content/sales-rep-thumbnails/${thumbName}`;
+            }
+
+            const newPreviews = {};
+            for (const [size, url] of Object.entries(asset.previewUrls || {})) {
+              const name = path.basename(url);
+              const src = path.join(contentService.directories.previews, name);
+              const dest = path.join(repPreviewDir, name);
+              await fs.copyFile(src, dest);
+              newPreviews[size] = `${req.protocol}://${req.get('host')}/uploads/content/sales-rep-previews/${name}`;
+            }
+
+            await asset.update({ thumbnailUrl: asset.thumbnailUrl, previewUrls: newPreviews });
+          } catch (thumbErr) {
+            console.warn('⚠️ Failed to persist sales rep thumbnails:', thumbErr.message);
+          }
 
           results.push({
             filename: file.originalname,

--- a/shared/template-routes.js
+++ b/shared/template-routes.js
@@ -2,7 +2,7 @@ const express = require('express');
 const { Op } = require('sequelize');
 const TemplateService = require('./template-service');
 
-module.exports = function(app, sequelize, authenticateToken) {
+module.exports = function(app, sequelize, authenticateToken, contentService = null) {
   const router = express.Router();
   
   // Initialize models
@@ -485,6 +485,21 @@ The Knittt Team`,
       res.json(result);
     } catch (error) {
       console.error('Error listing templates:', error);
+      res.status(400).json({ error: error.message });
+    }
+  });
+
+  // Combined list of communication and content templates
+  router.get('/templates/combined', authenticateToken, async (req, res) => {
+    try {
+      const communication = await templateService.listTemplates(req.user.tenantId, req.query);
+      let content = { templates: [], pagination: {} };
+      if (contentService && contentService.getTemplates) {
+        content = await contentService.getTemplates(req.user.tenantId, req.query);
+      }
+      res.json({ communication, content });
+    } catch (error) {
+      console.error('Error listing combined templates:', error);
       res.status(400).json({ error: error.message });
     }
   });


### PR DESCRIPTION
## Summary
- keep sales rep thumbnails in dedicated folders
- expose sales rep thumbnail and preview folders via express
- ensure upload directories exist on init
- add combined template listing endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861eabbbee483318343772cfef8f9ed