### PR TITLE
Document and clean up journey features

### DIFF
--- a/docs/journey-features.md
+++ b/docs/journey-features.md
@@ -1,0 +1,13 @@
+# Journey Features
+
+The journey module automates follow-up steps for leads. Supported action types are:
+
+- **call** – place outbound calls with transfer group support
+- **sms** – send templated SMS messages via Twilio or Meera
+- **email** – deliver templated email messages
+- **status_change** – update the lead's status field
+- **tag_update** – add or remove tags on a lead
+- **webhook** – POST data to external systems
+- **delay** – pause for a specified period before the next step
+
+Action types previously listed but not yet implemented have been removed from the models.

--- a/shared/journey-models.js
+++ b/shared/journey-models.js
@@ -91,9 +91,16 @@ module.exports = (sequelize) => {
       defaultValue: 0
     },
     actionType: {
-      type: DataTypes.ENUM('call', 'sms', 'email', 'status_change', 'tag_update', 'webhook', 
-                           'wait_for_event', 'conditional_branch', 'lead_assignment', 
-                           'data_update', 'journey_transfer', 'delay'),
+      // Supported actions currently implemented by JourneyService
+      type: DataTypes.ENUM(
+        'call',
+        'sms',
+        'email',
+        'status_change',
+        'tag_update',
+        'webhook',
+        'delay'
+      ),
       allowNull: false
     },
     actionConfig: {


### PR DESCRIPTION
## Summary
- limit `actionType` enum to implemented actions
- add documentation describing available journey features

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6861eb3ea0988331942810166b7f8515