### PR TITLE
Document sales rep photo API and add fallback retrieval

### DIFF
--- a/docs/sales-rep-photo-api.md
+++ b/docs/sales-rep-photo-api.md
@@ -1,0 +1,36 @@
+# Sales Rep Photo API
+
+These endpoints let you upload and manage sales rep photos used in announcement templates. All routes require Bearer authentication and are prefixed with `/api`.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/sales-rep-photos/upload` | Upload a photo for a single sales rep. Form fields: `photo`, `repEmail`, optional `repName`. |
+| `POST` | `/sales-rep-photos/bulk-upload` | Bulk upload multiple photos. Accepts `photos` files array and `mappings` JSON describing `{filename,email,name}`. |
+| `POST` | `/sales-rep-photos/fallback` | Set or replace the default fallback photo shown when a rep photo is missing. |
+| `GET` | `/sales-rep-photos/fallback` | Retrieve the current fallback photo. Returns 404 if not configured. |
+| `GET` | `/sales-rep-photos/by-email/:email` | Fetch a photo asset by rep email address. |
+| `GET` | `/sales-rep-photos` | List uploaded sales rep photos with pagination. Supports `page` and `limit` query params. |
+| `POST` | `/sales-rep-photos/generate-video` | Produce a celebration video using the rep photo. Body fields: `repEmail`, optional `repName`, `dealAmount`, `companyName`. |
+| `DELETE` | `/sales-rep-photos/:id` | Delete a photo asset by ID. |
+
+## Quick Test
+The setup script provides example commands for uploading a photo and triggering a webhook:
+
+```bash
+curl -X POST http://localhost:3001/api/sales-rep-photos/upload \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -F "photo=@test.jpg" \
+  -F "repEmail=john@company.com" \
+  -F "repName=John Doe"
+```
+
+```bash
+curl -X POST http://localhost:3001/api/webhooks/endpoint/YOUR_ENDPOINT_KEY \
+  -H "Authorization: Bearer YOUR_WEBHOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "salesRep": {"name": "John Doe", "email": "john@company.com"},
+    "deal": {"value": "$50,000"},
+    "client": {"company": "Acme Corp"}
+  }'
+```

--- a/shared/sales-rep-photo-routes.js
+++ b/shared/sales-rep-photo-routes.js
@@ -349,6 +349,34 @@ module.exports = function(app, sequelize, authenticateToken, contentService) {
     }
   });
 
+  // Get current fallback photo
+  router.get('/sales-rep-photos/fallback', authenticateToken, async (req, res) => {
+    try {
+      const asset = await ContentAsset.findOne({
+        where: {
+          tenantId: req.user.tenantId,
+          metadata: {
+            [sequelize.Sequelize.Op.jsonSupersetOf]: { isFallbackPhoto: true }
+          }
+        },
+        order: [['createdAt', 'DESC']]
+      });
+
+      if (!asset) {
+        return res.status(404).json({ error: 'Fallback photo not configured' });
+      }
+
+      res.json({
+        id: asset.id,
+        url: asset.publicUrl,
+        thumbnailUrl: asset.thumbnailUrl
+      });
+    } catch (error) {
+      console.error('Error retrieving fallback photo:', error);
+      res.status(400).json({ error: error.message });
+    }
+  });
+
   // Get sales rep photo by email - FIXED query
   router.get('/sales-rep-photos/by-email/:email', authenticateToken, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- document endpoints for managing sales rep photos
- allow retrieving the fallback photo via `/sales-rep-photos/fallback`

## Testing
- `node e2e-test.js` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_6862136f61f88331b323cf5b1a6da617