### PR TITLE
Add sales rep photo element

### DIFF
--- a/docs/content-creator-api.md
+++ b/docs/content-creator-api.md
@@ -46,6 +46,9 @@ Upload and manage assets used by elements.
 | `POST` | `/api/content/assets/upload` | Upload a new asset file. |
 | `DELETE` | `/api/content/assets/:assetId` | Remove an asset. |
 
+### Sales Rep Photo Element
+Templates can include an element with `elementType: "sales_rep_photo"`. When a project is generated from a webhook, the system automatically fills the element's `src` with the sales representative's photo based on the `{rep_photo}` variable.
+
 ## Variables and Exporting
 
 | Method | Path | Description |

--- a/docs/sales-rep-photo-api.md
+++ b/docs/sales-rep-photo-api.md
@@ -2,6 +2,8 @@
 
 These endpoints let you upload and manage sales rep photos used in announcement templates. All routes require Bearer authentication and are prefixed with `/api`.
 
+When using the Content Creator, you can place a photo on the canvas by adding an element with `elementType: "sales_rep_photo"`. The element automatically binds to the `{rep_photo}` variable so that the correct representative's image is displayed when a deal is closed.
+
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | `POST` | `/sales-rep-photos/upload` | Upload a photo for a single sales rep. Form fields: `photo`, `repEmail`, optional `repName`. |

--- a/shared/content-creation-integration.js
+++ b/shared/content-creation-integration.js
@@ -1241,6 +1241,27 @@ async function initializeElementLibrary(contentModels) {
           display: 'block'
         }
       },
+      {
+        name: 'Sales Rep Photo',
+        description: 'Photo of the sales rep pulled from uploaded assets',
+        elementType: 'sales_rep_photo',
+        category: 'Media',
+        subcategory: 'Dynamic',
+        isPublic: true,
+        difficulty: 'beginner',
+        tags: ['sales', 'rep', 'photo'],
+        defaultProperties: {
+          src: '{rep_photo}',
+          fit: 'cover',
+          borderRadius: '50%'
+        },
+        defaultStyles: {
+          width: '400px',
+          height: '400px',
+          borderRadius: '50%',
+          objectFit: 'cover'
+        }
+      },
       
       {
         name: 'Image Carousel',

--- a/shared/content-creation-models.js
+++ b/shared/content-creation-models.js
@@ -330,7 +330,7 @@ elementType: {
     'gradient_text', 'outline_text', 'shadow_text',
     
     // Media Elements
-    'image', 'standard_photo', 'video', 'audio', 'image_carousel', 'image_gallery', 
+    'image', 'sales_rep_photo', 'standard_photo', 'video', 'audio', 'image_carousel', 'image_gallery',
     'slideshow', 'video_playlist', 'audio_playlist',
     
     // Interactive Elements

--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -48,7 +48,7 @@ class ContentCreationService {
     // Element type categorization
     this.elementCategories = {
       'Text': ['text', 'marquee_text', 'typewriter_text', 'countdown_text', 'gradient_text', 'outline_text', 'shadow_text'],
-      'Media': ['image', 'standard_photo', 'video', 'audio', 'image_carousel', 'image_gallery', 'slideshow', 'video_playlist', 'audio_playlist'],
+      'Media': ['image', 'sales_rep_photo', 'standard_photo', 'video', 'audio', 'image_carousel', 'image_gallery', 'slideshow', 'video_playlist', 'audio_playlist'],
       'Interactive': ['button', 'slider', 'toggle', 'dropdown', 'tabs', 'accordion', 'modal', 'tooltip', 'hotspot', 'image_map'],
       'Forms': ['input_field', 'textarea', 'checkbox', 'radio_button', 'select_dropdown', 'file_upload', 'date_picker', 'color_picker'],
       'Layout': ['container', 'grid', 'flexbox', 'divider', 'spacer', 'columns', 'section', 'header', 'footer']
@@ -204,7 +204,7 @@ async processProjectImagesForExport(project) {
     let processedCount = 0;
     
     for (const element of elements) {
-      if (element.elementType === 'image' || element.elementType === 'standard_photo') {
+      if (element.elementType === 'image' || element.elementType === 'standard_photo' || element.elementType === 'sales_rep_photo') {
         const imageUrl = element.properties?.imageUrl || 
                         element.properties?.src || 
                         element.properties?.url;
@@ -671,7 +671,7 @@ async getTemplate(templateId, tenantId) {
       }
 
       // NEW: Download external images immediately when creating image elements
-      if ((elementData.elementType === 'image' || elementData.elementType === 'standard_photo') && elementData.properties) {
+      if ((elementData.elementType === 'image' || elementData.elementType === 'standard_photo' || elementData.elementType === 'sales_rep_photo') && elementData.properties) {
         const imageUrl = elementData.properties.imageUrl || 
                         elementData.properties.src || 
                         elementData.properties.url;
@@ -751,7 +751,7 @@ async getTemplate(templateId, tenantId) {
       }
 
       // NEW: Download external images when updating image elements
-      if ((element.elementType === 'image' || element.elementType === 'standard_photo') && updateData.properties) {
+      if ((element.elementType === 'image' || element.elementType === 'standard_photo' || element.elementType === 'sales_rep_photo') && updateData.properties) {
         const imageUrl = updateData.properties.imageUrl || 
                         updateData.properties.src || 
                         updateData.properties.url;
@@ -1819,6 +1819,7 @@ async generateElementHTML(element, options = {}) {
       
     case 'image':
     case 'standard_photo':
+    case 'sales_rep_photo':
       // NEW: Use base64 embedded images - no external URLs at all
       let imageUrl = properties.src || properties.url || properties.imageUrl || properties.assetId;
       

--- a/shared/deal-closed-announcement-template.js
+++ b/shared/deal-closed-announcement-template.js
@@ -117,7 +117,7 @@ const dealClosedTemplate = {
       ]
     },
     {
-      elementType: "image",
+      elementType: "sales_rep_photo",
       name: "Sales Rep Photo",
       position: { x: 720, y: 210, z: 6 },
       size: { width: 480, height: 480 },

--- a/shared/setup/setup-sales-rep-photos.js
+++ b/shared/setup/setup-sales-rep-photos.js
@@ -141,7 +141,7 @@ const setupSalesRepPhotoFeature = async (sequelize, contentService) => {
             ]
           },
           salesRepPhoto: {
-            elementType: "image",
+            elementType: "sales_rep_photo",
             name: "Sales Rep Photo",
             position: { x: 720, y: 210, z: 6 },
             size: { width: 480, height: 480 },

--- a/shared/webhook-service.js
+++ b/shared/webhook-service.js
@@ -671,8 +671,8 @@ class WebhookService {
             }
           }
 
-          // Special handling for image elements
-          if (element.elementType === 'image' && element.properties.src) {
+          // Special handling for image or sales rep photo elements
+          if ((element.elementType === 'image' || element.elementType === 'sales_rep_photo') && element.properties.src) {
             // Check if src contains a variable placeholder for photo
             if (element.properties.src.includes('{rep_photo}') && variables.rep_photo) {
               updatedProperties.src = variables.rep_photo;


### PR DESCRIPTION
## Summary
- allow `sales_rep_photo` element type in content models and service
- support new element in content creation integration & webhook variable injection
- use the new element in the sales rep photo template and setup script
- document the `sales_rep_photo` element

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68621ba09e588331a25b8ff383c87be2