### PR TITLE
Fix announcement webhook metrics

### DIFF
--- a/shared/webhook-service.js
+++ b/shared/webhook-service.js
@@ -297,6 +297,7 @@ class WebhookService {
     const processingStartTime = Date.now();
     const announcementMetricData = {
       webhookEndpointId: webhookEndpoint.id,
+      announcementStartTime: new Date(processingStartTime),
       contentProjectId: null,
       displayIds: [],
       successfulDisplays: 0,
@@ -491,6 +492,13 @@ class WebhookService {
       }
       
       // Step 6: Record metrics
+      announcementMetricData.announcementEndTime = new Date();
+      announcementMetricData.processingTime = Date.now() - processingStartTime;
+      announcementMetricData.totalDuration = Math.round(
+        (announcementMetricData.announcementEndTime -
+          announcementMetricData.announcementStartTime) /
+          1000
+      );
       await this.recordAnnouncementMetrics(announcementMetricData);
       
       return {
@@ -514,6 +522,13 @@ class WebhookService {
         stage: 'general',
         error: error.message
       });
+      announcementMetricData.announcementEndTime = new Date();
+      announcementMetricData.processingTime = Date.now() - processingStartTime;
+      announcementMetricData.totalDuration = Math.round(
+        (announcementMetricData.announcementEndTime -
+          announcementMetricData.announcementStartTime) /
+          1000
+      );
       await this.recordAnnouncementMetrics(announcementMetricData);
       
       throw error;
@@ -1089,6 +1104,17 @@ class WebhookService {
     } catch (error) {
       console.error('Error getting webhook events:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Record announcement metrics
+   */
+  async recordAnnouncementMetrics(metricData) {
+    try {
+      await this.models.AnnouncementMetric.create(metricData);
+    } catch (error) {
+      console.error('Error recording announcement metrics:', error);
     }
   }
 


### PR DESCRIPTION
## Summary
- initialize announcement metrics with start time
- track completion time and duration
- add `recordAnnouncementMetrics` helper

## Testing
- `node -e "require('./shared/webhook-service.js')"` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686234dc18048331921d8522aaa64179