### PR TITLE
Fix webhook integration service initialization

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -851,11 +851,12 @@ app.get('/api/proxy-image-cached', async (req, res) => {
 async function initializeModules() {
   console.log('Initializing modules...');
   
- try {
+  try {
     console.log('Initializing Optisigns module...');
     const initOptisigns = require('../shared/optisigns-integration');
     const optisignsIntegration = initOptisigns(app, sequelize, authenticateToken);
     optisignsModels = optisignsIntegration.models;
+    optisignsService = optisignsIntegration.services?.optisignsService;
     console.log('Optisigns module initialized successfully');
   } catch (error) {
     console.error('Error initializing Optisigns module:', error);
@@ -933,12 +934,13 @@ try {
   const initWebhooks = require('../shared/webhook-integration');
   
   // Pass the services as options
-  const webhookIntegration = initWebhooks(app, sequelize, authenticateToken, {
-    contentService: contentService,
-    contentModels: contentModels,
-    optisignsService: optisignsService,
-    optisignsModels: optisignsModels
-  });
+  const webhookIntegration = initWebhooks(
+    app,
+    sequelize,
+    authenticateToken,
+    { services: { contentService }, models: contentModels },
+    { services: { optisignsService }, models: optisignsModels }
+  );
   
   webhookModels = webhookIntegration.models;
   console.log('Enhanced Webhook Integration module initialized successfully with all services');
@@ -963,7 +965,13 @@ try {
 
   // Initialize the Webhook Integration module
   console.log('Initializing Webhook Integration module...');
-  const webhookIntegration = initWebhookIntegration(app, sequelize, authenticateToken);
+  const webhookIntegration = initWebhookIntegration(
+    app,
+    sequelize,
+    authenticateToken,
+    { services: { contentService }, models: contentModels },
+    { services: { optisignsService }, models: optisignsModels }
+  );
   console.log('Webhook Integration module initialized successfully');
 
   // Initialize Twilio module
@@ -1027,6 +1035,7 @@ try {
     const initOptisigns = require('../shared/optisigns-integration');
     const optisignsIntegration = initOptisigns(app, sequelize, authenticateToken);
     optisignsModels = optisignsIntegration.models;
+    optisignsService = optisignsIntegration.services?.optisignsService;
     console.log('Optisigns module initialized successfully');
   } catch (error) {
     console.error('Error initializing Optisigns module:', error);
@@ -2333,7 +2342,13 @@ cron.schedule('*/2 * * * *', async () => {
   try {
     if (webhookModels && webhookModels.WebhookService) {
       // Get webhook service instance (you'll need to make this accessible)
-      const webhookIntegration = initWebhookIntegration(app, sequelize, authenticateToken);
+      const webhookIntegration = initWebhookIntegration(
+        app,
+        sequelize,
+        authenticateToken,
+        { services: { contentService }, models: contentModels },
+        { services: { optisignsService }, models: optisignsModels }
+      );
       const webhookService = webhookIntegration.services.webhookService;
       
       const processedCount = await webhookService.processScheduledResumes();
@@ -2351,7 +2366,13 @@ cron.schedule('*/5 * * * *', async () => {
   try {
     if (webhookModels && webhookModels.WebhookService) {
       // Get webhook service instance
-      const webhookIntegration = initWebhookIntegration(app, sequelize, authenticateToken);
+      const webhookIntegration = initWebhookIntegration(
+        app,
+        sequelize,
+        authenticateToken,
+        { services: { contentService }, models: contentModels },
+        { services: { optisignsService }, models: optisignsModels }
+      );
       const webhookService = webhookIntegration.services.webhookService;
       
       const resumedCount = await webhookService.checkResumeConditions();


### PR DESCRIPTION
## Summary
- ensure OptiSigns service instance is stored during initialization
- provide Content Creator and OptiSigns services when creating webhook modules
- pass these services in scheduled tasks so announcement webhooks work

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862dc7088d083318e6cd8036c458275