### PR TITLE
Fix sales rep photo lookup

### DIFF
--- a/backend/webhook-integration.js
+++ b/backend/webhook-integration.js
@@ -27,6 +27,9 @@ const initWebhooks = (app, sequelize, authenticateToken) => {
     {
       WebhookEndpoint: webhookModels.WebhookEndpoint,
       WebhookEvent: webhookModels.WebhookEvent,
+      ContentAsset: sequelize.models.ContentAsset,
+      OptisignsDisplay: sequelize.models.OptisignsDisplay,
+      OptisignsTakeover: sequelize.models.OptisignsTakeover,
       Lead: sequelize.models.Lead,
       Tenant: sequelize.models.Tenant
     },

--- a/backend/webhook-routes.js
+++ b/backend/webhook-routes.js
@@ -30,6 +30,9 @@ module.exports = function(app, sequelize, authenticateToken) {
     {
       WebhookEndpoint: webhookModels.WebhookEndpoint,
       WebhookEvent: webhookModels.WebhookEvent,
+      ContentAsset: sequelize.models.ContentAsset,
+      OptisignsDisplay: sequelize.models.OptisignsDisplay,
+      OptisignsTakeover: sequelize.models.OptisignsTakeover,
       Lead: sequelize.models.Lead,
       Tenant: sequelize.models.Tenant
     },

--- a/shared/webhook-integration.js
+++ b/shared/webhook-integration.js
@@ -61,14 +61,22 @@ module.exports = function(app, sequelize, authenticateToken, contentIntegration 
     }
     
     // Initialize enhanced webhook service with all required models and integrated services
-    const webhookService = new WebhookService({
-      WebhookEndpoint: webhookModels.WebhookEndpoint,
-      WebhookEvent: webhookModels.WebhookEvent,
-      LeadPauseState: webhookModels.LeadPauseState,
-      AnnouncementMetric: webhookModels.AnnouncementMetric,
-      Lead: sequelize.models.Lead,
-      Tenant: sequelize.models.Tenant
-    }, journeyService, contentService, optisignsService);
+    const webhookService = new WebhookService(
+      {
+        WebhookEndpoint: webhookModels.WebhookEndpoint,
+        WebhookEvent: webhookModels.WebhookEvent,
+        LeadPauseState: webhookModels.LeadPauseState,
+        AnnouncementMetric: webhookModels.AnnouncementMetric,
+        ContentAsset: sequelize.models.ContentAsset,
+        OptisignsDisplay: sequelize.models.OptisignsDisplay,
+        OptisignsTakeover: sequelize.models.OptisignsTakeover,
+        Lead: sequelize.models.Lead,
+        Tenant: sequelize.models.Tenant,
+      },
+      journeyService,
+      contentService,
+      optisignsService
+    );
 
     // Log service availability
     const serviceStatus = {


### PR DESCRIPTION
## Summary
- include ContentAsset, OptisignsDisplay, and OptisignsTakeover models when initializing `WebhookService`
- update backend integrations to provide these models as well

This ensures sales rep photos and display selections work correctly for announcement webhooks.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862f20502888331a9e44371825bd501