### PR TITLE
Fix variable injection for announcement webhooks

### DIFF
--- a/shared/webhook-service.js
+++ b/shared/webhook-service.js
@@ -390,7 +390,11 @@ class WebhookService {
         console.log('✅ Created content project:', contentProject.id);
 
         // Inject variables into project elements (including photo)
-        await this.injectVariablesIntoProject(contentProject.id, extractedVariables.variables);
+        await this.injectVariablesIntoProject(
+          contentProject.id,
+          extractedVariables.variables,
+          webhookEndpoint.tenantId
+        );
         
       } catch (error) {
         console.error('❌ Failed to create content project:', error);
@@ -682,12 +686,12 @@ class WebhookService {
   /**
    * Inject variables into content project elements (ENHANCED FOR IMAGES)
    */
-  async injectVariablesIntoProject(projectId, variables) {
+  async injectVariablesIntoProject(projectId, variables, tenantId = null) {
     try {
       // Get project with elements
       const project = await this.contentService.getProjectWithElements(
         projectId,
-        null // We'll handle tenant validation in the service
+        tenantId // Pass through tenant for proper lookup
       );
       
       if (!project || !project.elements) {


### PR DESCRIPTION
## Summary
- pass tenant ID when injecting variables into content projects
- update injectVariablesIntoProject to accept tenant ID

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862f5fa3b24833193e4ba468301e95d