### PR TITLE
Fix OptiSigns ID usage

### DIFF
--- a/shared/optisigns-routes.js
+++ b/shared/optisigns-routes.js
@@ -253,7 +253,7 @@ module.exports = function(app, sequelize, authenticateToken, optisignsModels, op
       try {
         liveDisplay = await optisignsService.getDevice(
           tenantId,
-          display.optisignsDisplayId
+          display.uuid || display.optisignsDisplayId
         );
         await display.update({
           name: liveDisplay.deviceName || liveDisplay.name || display.name,
@@ -301,7 +301,7 @@ module.exports = function(app, sequelize, authenticateToken, optisignsModels, op
       // Update in OptiSigns
       const updatedDevice = await optisignsService.updateDevice(
         req.user.tenantId,
-        display.optisignsDisplayId,
+        display.uuid || display.optisignsDisplayId,
         updates
       );
 
@@ -347,7 +347,7 @@ module.exports = function(app, sequelize, authenticateToken, optisignsModels, op
 
       const updatedDevice = await optisignsService.addTags(
         req.user.tenantId,
-        display.optisignsDisplayId,
+        display.uuid || display.optisignsDisplayId,
         tags
       );
 
@@ -384,7 +384,7 @@ module.exports = function(app, sequelize, authenticateToken, optisignsModels, op
 
       const updatedDevice = await optisignsService.removeTags(
         req.user.tenantId,
-        display.optisignsDisplayId,
+        display.uuid || display.optisignsDisplayId,
         tags
       );
 

--- a/shared/optisigns-service.js
+++ b/shared/optisigns-service.js
@@ -692,8 +692,9 @@ class OptisignsService {
       if (updates.location) deviceUpdates.location = updates.location;
       // Add other valid fields as needed
       
-      const device = await this.safeApiCall(() => 
-        client.devices.updateDevice(deviceId, deviceUpdates)
+      const apiDeviceId = deviceId;
+      const device = await this.safeApiCall(() =>
+        client.devices.updateDevice(apiDeviceId, deviceUpdates)
       );
       
       console.log('✅ Device updated successfully');
@@ -717,8 +718,9 @@ class OptisignsService {
       
       // The SDK might have a specific method for tags
       // If not, use updateDevice with tags field
-      const device = await this.safeApiCall(() => 
-        client.devices.updateDevice(deviceId, { tags })
+      const apiDeviceId = deviceId;
+      const device = await this.safeApiCall(() =>
+        client.devices.updateDevice(apiDeviceId, { tags })
       );
       
       return device;
@@ -944,12 +946,13 @@ class OptisignsService {
         }
       }
 
-      console.log(`🚀 Using SDK updateDevice: device=${device.optisignsDisplayId}, content=${optisignsContentId}, team=${teamId}`);
+      const apiDeviceId = device.uuid || device.optisignsDisplayId;
+      console.log(`🚀 Using SDK updateDevice: device=${apiDeviceId}, content=${optisignsContentId}, team=${teamId}`);
 
       // Use SDK updateDevice method to assign content
       const result = await this.safeApiCall(() => 
         client.devices.updateDevice(
-          device.optisignsDisplayId,
+          apiDeviceId,
           {
             currentAssetId: optisignsContentId,
             currentType: 'ASSET'
@@ -1068,9 +1071,10 @@ class OptisignsService {
       }
 
       // Clear by setting empty values using updateDevice
-      const result = await this.safeApiCall(() => 
+      const apiDeviceId = device.uuid || device.optisignsDisplayId;
+      const result = await this.safeApiCall(() =>
         client.devices.updateDevice(
-          device.optisignsDisplayId,
+          apiDeviceId,
           {
             currentAssetId: null,
             currentType: null
@@ -1141,11 +1145,12 @@ class OptisignsService {
       const client = await this.getClient(tenantId);
       
       try {
-        console.log(`🚀 Using SDK updateDevice for takeover: device=${device.optisignsDisplayId}, content=${resolvedContent.optisignsId}, team=${effectiveTeamId}`);
-        
-        await this.safeApiCall(() => 
+        const apiDeviceId = device.uuid || device.optisignsDisplayId;
+        console.log(`🚀 Using SDK updateDevice for takeover: device=${apiDeviceId}, content=${resolvedContent.optisignsId}, team=${effectiveTeamId}`);
+
+        await this.safeApiCall(() =>
           client.devices.updateDevice(
-            device.optisignsDisplayId,
+            apiDeviceId,
             {
               currentAssetId: resolvedContent.optisignsId,
               currentType: contentType
@@ -1485,9 +1490,10 @@ class OptisignsService {
           const teamId = config?.settings?.teamId || config?.settings?.defaultTeamId || null;
           
           // Use updateDevice to restore previous content
-          await this.safeApiCall(() => 
+          const apiDeviceId = device.uuid || device.optisignsDisplayId;
+          await this.safeApiCall(() =>
             client.devices.updateDevice(
-              device.optisignsDisplayId,
+              apiDeviceId,
               {
                 currentAssetId: takeover.previousContentId,
                 currentType: takeover.previousContentType || 'ASSET'
@@ -1635,8 +1641,9 @@ class OptisignsService {
       const client = await this.getClient(tenantId);
       
       // Get current device to find existing tags
-      const device = await this.safeApiCall(() => 
-        client.devices.getDeviceById(deviceId)
+      const apiDeviceId = deviceId;
+      const device = await this.safeApiCall(() =>
+        client.devices.getDeviceById(apiDeviceId)
       );
       
       // Remove specified tags
@@ -1644,8 +1651,8 @@ class OptisignsService {
       const updatedTags = currentTags.filter(tag => !tags.includes(tag));
       
       // Update device with new tags
-      const updatedDevice = await this.safeApiCall(() => 
-        client.devices.updateDevice(deviceId, { tags: updatedTags })
+      const updatedDevice = await this.safeApiCall(() =>
+        client.devices.updateDevice(apiDeviceId, { tags: updatedTags })
       );
       
       return updatedDevice;

--- a/shared/webhook-service.js
+++ b/shared/webhook-service.js
@@ -299,6 +299,7 @@ class WebhookService {
   async processAnnouncementWebhook(webhookEndpoint, payload) {
     const processingStartTime = Date.now();
     const announcementMetricData = {
+      tenantId: webhookEndpoint.tenantId,
       webhookEndpointId: webhookEndpoint.id,
       announcementStartTime: new Date(processingStartTime),
       contentProjectId: null,


### PR DESCRIPTION
## Summary
- use OptiSigns device UUID when updating devices
- pass tenantId when recording announcement metrics

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6862f82e555c8331aa0011f22615088e