### PR TITLE
Fix missing sales rep photo error

### DIFF
--- a/docs/sales-rep-photo-api.md
+++ b/docs/sales-rep-photo-api.md
@@ -37,3 +37,11 @@ curl -X POST http://localhost:3001/api/webhooks/endpoint/YOUR_ENDPOINT_KEY \
     "client": {"company": "Acme Corp"}
   }'
 ```
+
+## Default Fallback Photo
+
+If no uploaded fallback is found, the webhook service can use a static image by
+setting the `DEFAULT_REP_PHOTO_URL` environment variable. This URL should point
+to a publicly accessible image (e.g. `https://example.com/default.png`). When
+defined, the service will automatically use this image whenever a rep photo and
+uploaded fallback are both missing.

--- a/shared/webhook-service.js
+++ b/shared/webhook-service.js
@@ -582,8 +582,16 @@ class WebhookService {
             variables.rep_photo_id = fallbackPhoto.id;
             console.log(`📷 Using fallback photo for ${repEmail}`);
           } else {
-            missing.push('rep_photo');
-            console.log(`❌ No photo found for ${repEmail} and no fallback configured`);
+            const defaultPhoto = process.env.DEFAULT_REP_PHOTO_URL;
+            if (defaultPhoto) {
+              variables.rep_photo = defaultPhoto;
+              console.log(
+                `⚠️ No photo found for ${repEmail}. Using DEFAULT_REP_PHOTO_URL`
+              );
+            } else {
+              missing.push('rep_photo');
+              console.log(`❌ No photo found for ${repEmail} and no fallback configured`);
+            }
           }
         }
       } catch (error) {
@@ -675,6 +683,11 @@ class WebhookService {
           url: fallbackAsset.publicUrl || fallbackAsset.url,
           thumbnailUrl: fallbackAsset.thumbnailUrl
         };
+      }
+
+      const defaultPhoto = process.env.DEFAULT_REP_PHOTO_URL;
+      if (defaultPhoto) {
+        return { id: null, url: defaultPhoto, thumbnailUrl: defaultPhoto };
       }
 
       return null;


### PR DESCRIPTION
## Summary
- allow fallback to default rep photo URL when not configured
- document DEFAULT_REP_PHOTO_URL in sales rep photo guide

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68630251b36c8331bcf9501984b3fd2b