### PR TITLE
Fix syntax typo in webhook integration

### DIFF
--- a/shared/webhook-integration.js
+++ b/shared/webhook-integration.js
@@ -93,12 +93,9 @@ module.exports = function(app, sequelize, authenticateToken, contentIntegration 
         Lead: sequelize.models.Lead,
         Tenant: sequelize.models.Tenant,
         ContentAsset: contentModels?.ContentAsset || sequelize.models.ContentAsset,
-        Sequelize: sequelize.Sequelize
-        ContentAsset: sequelize.models.ContentAsset,
+        Sequelize: sequelize.Sequelize,
         OptisignsDisplay: sequelize.models.OptisignsDisplay,
-        OptisignsTakeover: sequelize.models.OptisignsTakeover,
-        Lead: sequelize.models.Lead,
-        Tenant: sequelize.models.Tenant,
+        OptisignsTakeover: sequelize.models.OptisignsTakeover
 
       },
       journeyService,


### PR DESCRIPTION
## Summary
- fix duplicated property block and missing comma in `webhook-integration.js`

## Testing
- `node -c shared/webhook-integration.js`


------
https://chatgpt.com/codex/tasks/task_e_6863073d90ec8331a0ddcb4f631365d5