### PR TITLE
Fix syntax error in webhook integration

### DIFF
--- a/shared/webhook-integration.js
+++ b/shared/webhook-integration.js
@@ -93,13 +93,9 @@ module.exports = function(app, sequelize, authenticateToken, contentIntegration 
         Lead: sequelize.models.Lead,
         Tenant: sequelize.models.Tenant,
         ContentAsset: contentModels?.ContentAsset || sequelize.models.ContentAsset,
-        Sequelize: sequelize.Sequelize
-        ContentAsset: sequelize.models.ContentAsset,
+        Sequelize: sequelize.Sequelize,
         OptisignsDisplay: sequelize.models.OptisignsDisplay,
         OptisignsTakeover: sequelize.models.OptisignsTakeover,
-        Lead: sequelize.models.Lead,
-        Tenant: sequelize.models.Tenant,
-
       },
       journeyService,
       contentService,


### PR DESCRIPTION
## Summary
- remove duplicate property lines in webhook integration config
- add missing comma after `Sequelize`

## Testing
- `node --check shared/webhook-integration.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863073d90ec8331a0ddcb4f631365d5