### PR TITLE
Handle medium takeover priority

### DIFF
--- a/shared/webhook-integration.js
+++ b/shared/webhook-integration.js
@@ -418,7 +418,7 @@ function initializeAnnouncementRoutes(app, authenticateToken, webhookModels, web
             optisigns: {
               displaySelection: { mode: 'all' },
               takeover: {
-                priority: 'MEDIUM',
+                priority: 'NORMAL',
                 duration: 45,
                 restoreAfter: true
               }
@@ -447,7 +447,7 @@ function initializeAnnouncementRoutes(app, authenticateToken, webhookModels, web
             optisigns: {
               displaySelection: { mode: 'all' },
               takeover: {
-                priority: 'MEDIUM',
+                priority: 'NORMAL',
                 duration: 35,
                 restoreAfter: true
               }


### PR DESCRIPTION
## Summary
- normalize OptiSigns takeover priority values to supported enum
- use normalized priority when initiating device takeover
- adjust default priorities in webhook integration

## Testing
- `npm test` in backend (fails: Missing script)
- `npm test` in worker (fails: Missing script)
- `npm test` in dialplan-builder/frontend (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_6864316b21e883318dc9a100bbdf1843