### PR TITLE
Add video background and celebration video features

### DIFF
--- a/docs/content-creator-api.md
+++ b/docs/content-creator-api.md
@@ -49,6 +49,9 @@ Upload and manage assets used by elements.
 ### Sales Rep Photo Element
 Templates can include an element with `elementType: "sales_rep_photo"`. When a project is generated from a webhook, the system automatically fills the element's `src` with the sales representative's photo based on the `{rep_photo}` variable.
 
+### Video Backgrounds
+Projects may define `canvasBackground.type: "video"` with a `url` to a video asset. When exported, the video is embedded in the generated HTML as a looping, muted element behind all other content.
+
 ## Variables and Exporting
 
 | Method | Path | Description |


### PR DESCRIPTION
## Summary
- support video backgrounds in exported HTML
- add video processing helpers for assets
- allow generating celebration videos from sales rep photos
- document video backgrounds

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686433d276fc8331877b62c868fa514c