### PR TITLE
Fix optisigns playlist id column type

### DIFF
--- a/shared/optisigns-models.js
+++ b/shared/optisigns-models.js
@@ -96,8 +96,12 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: 'current_content_id'
     },
+    // currentPlaylistId comes directly from OptiSigns and is not a UUID in
+    // their API.  Using STRING here avoids schema migrations attempting to
+    // cast existing values to UUID which caused startup errors when syncing
+    // the models.
     currentPlaylistId: {
-      type: DataTypes.UUID,
+      type: DataTypes.STRING,
       allowNull: true,
       field: 'current_playlist_id'
     },


### PR DESCRIPTION
## Summary
- match OptiSigns display model with existing DB schema
- avoid UUID cast error by storing `currentPlaylistId` as a string

## Testing
- `npm test` *(fails: no package.json in repo root)*

------
https://chatgpt.com/codex/tasks/task_e_6864568338388331a0092620fecedbe1