### PR TITLE
Fix optisigns status column types

### DIFF
--- a/shared/optisigns-models.js
+++ b/shared/optisigns-models.js
@@ -403,8 +403,11 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       defaultValue: 'NORMAL'
     },
+    // Use STRING instead of ENUM to avoid type casting issues when the
+    // schema evolves. Status values are validated at the application
+    // level, so an explicit ENUM is not required here.
     status: {
-      type: DataTypes.ENUM('SCHEDULED', 'ACTIVE', 'COMPLETED', 'CANCELLED', 'FAILED'),
+      type: DataTypes.STRING,
       allowNull: false,
       defaultValue: 'SCHEDULED'
     },
@@ -758,8 +761,10 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       field: 'end_time'
     },
+    // Store status as STRING to make schema migrations easier. Allowed
+    // values are enforced in the application code.
     status: {
-      type: DataTypes.ENUM('SCHEDULED', 'ACTIVE', 'COMPLETED', 'CANCELLED'),
+      type: DataTypes.STRING,
       defaultValue: 'SCHEDULED'
     },
     isRecurring: {


### PR DESCRIPTION
## Summary
- avoid enum casts when syncing optisigns models by storing `status` as `STRING`

## Testing
- `bash test_new_user.sh` *(fails: unable to ssh into remote host)*
- `npm test` *(no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68645daea51c8331b59c75b5b1a91621