### PR TITLE
Add marketing service

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -70,6 +70,7 @@ let contentModels = null;
 let contentService = null;
 let optisignsService = null; // FIXED: Properly declared as global
 let billingModels = null;
+let marketingModels = null;
 
 // Utility: ensure optisigns_displays.current_playlist_id column uses UUID type
 async function fixCurrentPlaylistColumn(sequelize) {
@@ -555,6 +556,15 @@ async function initializeModules() {
     console.error('Error initializing billing module:', error);
   }
 
+  // Initialize marketing module
+  try {
+    const initMarketing = require('../shared/marketing-routes');
+    marketingModels = initMarketing(app, sequelize, authenticateToken);
+    console.log('Marketing module initialized successfully');
+  } catch (error) {
+    console.error('Error initializing marketing module:', error);
+  }
+
   try {
     const initRecordings = require('../shared/recording-routes');
     recordingModels = initRecordings(app, sequelize, authenticateToken);
@@ -575,7 +585,8 @@ async function initializeModules() {
   return {
     dialplanBuilder,
     recordingModels,
-    reportBuilderModels
+    reportBuilderModels,
+    marketingModels
   };
 }
 

--- a/docs/marketing-api.md
+++ b/docs/marketing-api.md
@@ -1,0 +1,33 @@
+# Marketing Service API
+
+The marketing service allows linking advertising accounts and tracking campaign metrics.
+All routes are mounted under `/api` and require authentication.
+
+## Link an Ad Account
+`POST /marketing/accounts`
+```json
+{
+  "platform": "facebook",
+  "accountId": "123",
+  "tokens": { "accessToken": "token" }
+}
+```
+
+## List Accounts
+`GET /marketing/accounts`
+
+## Create Campaign
+`POST /marketing/campaigns`
+```json
+{
+  "adAccountId": 1,
+  "data": {
+    "externalId": "abc",
+    "name": "My Campaign",
+    "cost": 100
+  }
+}
+```
+
+## Get Campaign Metrics
+`GET /marketing/campaigns/:id/metrics`

--- a/shared/marketing-models.js
+++ b/shared/marketing-models.js
@@ -1,0 +1,44 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = function(sequelize) {
+  const AdAccount = sequelize.define('AdAccount', {
+    tenantId: { type: DataTypes.STRING, allowNull: false },
+    platform: { type: DataTypes.ENUM('facebook', 'google', 'tiktok'), allowNull: false },
+    accountId: { type: DataTypes.STRING, allowNull: false },
+    accessToken: { type: DataTypes.TEXT, allowNull: true },
+    refreshToken: { type: DataTypes.TEXT, allowNull: true },
+    tokenExpiresAt: { type: DataTypes.DATE, allowNull: true },
+    metadata: { type: DataTypes.JSONB, defaultValue: {} },
+    isActive: { type: DataTypes.BOOLEAN, defaultValue: true }
+  });
+
+  const AdCampaign = sequelize.define('AdCampaign', {
+    tenantId: { type: DataTypes.STRING, allowNull: false },
+    adAccountId: { type: DataTypes.INTEGER, allowNull: false },
+    externalId: { type: DataTypes.STRING, allowNull: false },
+    name: { type: DataTypes.STRING, allowNull: false },
+    params: { type: DataTypes.JSONB, defaultValue: {} },
+    cost: { type: DataTypes.DECIMAL(10,2), defaultValue: 0 },
+    leads: { type: DataTypes.INTEGER, defaultValue: 0 },
+    conversions: { type: DataTypes.INTEGER, defaultValue: 0 },
+    startDate: { type: DataTypes.DATE, allowNull: true },
+    endDate: { type: DataTypes.DATE, allowNull: true }
+  });
+
+  const AdLead = sequelize.define('AdLead', {
+    tenantId: { type: DataTypes.STRING, allowNull: false },
+    adCampaignId: { type: DataTypes.INTEGER, allowNull: false },
+    externalLeadId: { type: DataTypes.STRING, allowNull: true },
+    leadId: { type: DataTypes.INTEGER, allowNull: true },
+    data: { type: DataTypes.JSONB, defaultValue: {} },
+    importedAt: { type: DataTypes.DATE, defaultValue: DataTypes.NOW }
+  });
+
+  AdAccount.hasMany(AdCampaign, { foreignKey: 'adAccountId' });
+  AdCampaign.belongsTo(AdAccount, { foreignKey: 'adAccountId' });
+
+  AdCampaign.hasMany(AdLead, { foreignKey: 'adCampaignId' });
+  AdLead.belongsTo(AdCampaign, { foreignKey: 'adCampaignId' });
+
+  return { AdAccount, AdCampaign, AdLead };
+};

--- a/shared/marketing-routes.js
+++ b/shared/marketing-routes.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const MarketingService = require('./marketing-service');
+
+module.exports = function(app, sequelize, authenticateToken) {
+  const router = express.Router();
+  const models = require('./marketing-models')(sequelize);
+  const service = new MarketingService(models);
+
+  router.post('/marketing/accounts', authenticateToken, async (req, res) => {
+    try {
+      const { platform, accountId, tokens, metadata } = req.body;
+      const account = await service.linkAccount(req.user.tenantId, platform, accountId, tokens, metadata);
+      res.json(account);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.get('/marketing/accounts', authenticateToken, async (req, res) => {
+    try {
+      const accounts = await service.listAccounts(req.user.tenantId);
+      res.json(accounts);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.post('/marketing/campaigns', authenticateToken, async (req, res) => {
+    try {
+      const { adAccountId, data } = req.body;
+      const campaign = await service.createCampaign(req.user.tenantId, adAccountId, data);
+      res.json(campaign);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.get('/marketing/campaigns/:id/metrics', authenticateToken, async (req, res) => {
+    try {
+      const metrics = await service.getCampaignMetrics(req.params.id);
+      res.json(metrics);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  app.use('/api', router);
+  return models;
+};

--- a/shared/marketing-service.js
+++ b/shared/marketing-service.js
@@ -1,0 +1,85 @@
+class MarketingService {
+  constructor(models) {
+    this.models = models;
+  }
+
+  async linkAccount(tenantId, platform, accountId, tokens = {}, metadata = {}) {
+    const [account] = await this.models.AdAccount.findOrCreate({
+      where: { tenantId, platform, accountId },
+      defaults: {
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        tokenExpiresAt: tokens.tokenExpiresAt,
+        metadata
+      }
+    });
+
+    if (!account.isNewRecord) {
+      await account.update({
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        tokenExpiresAt: tokens.tokenExpiresAt,
+        metadata
+      });
+    }
+    return account;
+  }
+
+  listAccounts(tenantId) {
+    return this.models.AdAccount.findAll({ where: { tenantId } });
+  }
+
+  async createCampaign(tenantId, adAccountId, data) {
+    const campaign = await this.models.AdCampaign.create({
+      tenantId,
+      adAccountId,
+      externalId: data.externalId,
+      name: data.name,
+      params: data.params || {},
+      cost: data.cost || 0,
+      startDate: data.startDate,
+      endDate: data.endDate
+    });
+    return campaign;
+  }
+
+  async recordLead(tenantId, campaignId, leadData) {
+    const campaign = await this.models.AdCampaign.findByPk(campaignId);
+    if (!campaign) throw new Error('Campaign not found');
+
+    await this.models.AdLead.create({
+      tenantId,
+      adCampaignId: campaignId,
+      externalLeadId: leadData.externalLeadId,
+      leadId: leadData.leadId,
+      data: leadData.data || {}
+    });
+
+    await campaign.increment('leads');
+  }
+
+  async recordConversion(campaignId) {
+    const campaign = await this.models.AdCampaign.findByPk(campaignId);
+    if (campaign) {
+      await campaign.increment('conversions');
+    }
+  }
+
+  async getCampaignMetrics(campaignId) {
+    const campaign = await this.models.AdCampaign.findByPk(campaignId);
+    if (!campaign) throw new Error('Campaign not found');
+
+    const cpl = campaign.leads > 0 ? parseFloat(campaign.cost) / campaign.leads : 0;
+    const cpa = campaign.conversions > 0 ? parseFloat(campaign.cost) / campaign.conversions : 0;
+
+    return {
+      cost: parseFloat(campaign.cost),
+      leads: campaign.leads,
+      conversions: campaign.conversions,
+      cpl,
+      cpa
+    };
+  }
+}
+
+module.exports = MarketingService;


### PR DESCRIPTION
## Summary
- create marketing models for ad accounts, campaigns and leads
- implement marketing service to manage accounts and campaigns
- expose marketing routes and docs
- integrate marketing service with backend server

## Testing
- `node -v`
- `node -e "require('./shared/marketing-service');console.log('loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_68649885916c833197968f14232e30e0