### PR TITLE
Add lead marketplace module

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -71,6 +71,7 @@ let contentService = null;
 let optisignsService = null; // FIXED: Properly declared as global
 let billingModels = null;
 let marketingModels = null;
+let marketplaceModels = null;
 
 // Utility: ensure optisigns_displays.current_playlist_id column uses UUID type
 async function fixCurrentPlaylistColumn(sequelize) {
@@ -565,6 +566,17 @@ async function initializeModules() {
     console.error('Error initializing marketing module:', error);
   }
 
+  // Initialize lead marketplace module
+  try {
+    const initMarketplaceModels = require('../shared/marketplace-models');
+    marketplaceModels = initMarketplaceModels(sequelize);
+    const initMarketplaceRoutes = require('../shared/marketplace-routes');
+    initMarketplaceRoutes(app, sequelize, authenticateToken);
+    console.log('Marketplace module initialized successfully');
+  } catch (error) {
+    console.error('Error initializing marketplace module:', error);
+  }
+
   try {
     const initRecordings = require('../shared/recording-routes');
     recordingModels = initRecordings(app, sequelize, authenticateToken);
@@ -586,7 +598,8 @@ async function initializeModules() {
     dialplanBuilder,
     recordingModels,
     reportBuilderModels,
-    marketingModels
+    marketingModels,
+    marketplaceModels
   };
 }
 
@@ -1108,7 +1121,7 @@ async function startServer() {
     console.log('Database models synchronized.');
     
     // Initialize modules before defining routes
-    const { dialplanBuilder, recordingModels, reportBuilderModels } = await initializeModules();
+    const { dialplanBuilder, recordingModels, reportBuilderModels, marketplaceModels } = await initializeModules();
     
     // Define all routes
     await defineRoutes(dialplanBuilder);

--- a/docs/marketplace-api.md
+++ b/docs/marketplace-api.md
@@ -1,0 +1,43 @@
+# Lead Marketplace API
+
+This module exposes endpoints for buying and selling leads. All routes are mounted under `/api` and require authentication.
+
+## Create Provider
+`POST /marketplace/providers`
+Payload:
+```json
+{
+  "name": "Lead Seller",
+  "description": "Quality solar leads",
+  "contact": { "email": "seller@example.com" }
+}
+```
+
+## List Providers
+`GET /marketplace/providers`
+
+## Create Listing
+`POST /marketplace/listings`
+```json
+{
+  "providerId": 1,
+  "name": "Solar Leads",
+  "pricePerLead": 5.00,
+  "deliveryMethod": "csv",
+  "availableLeads": 100
+}
+```
+
+## List Listings
+`GET /marketplace/listings`
+
+## Purchase Leads
+`POST /marketplace/listings/:id/purchase`
+```json
+{
+  "quantity": 10
+}
+```
+
+## List Orders
+`GET /marketplace/orders`

--- a/shared/marketplace-models.js
+++ b/shared/marketplace-models.js
@@ -1,0 +1,38 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = function(sequelize) {
+  const LeadProvider = sequelize.define('LeadProvider', {
+    tenantId: { type: DataTypes.STRING, allowNull: false },
+    name: { type: DataTypes.STRING, allowNull: false },
+    description: { type: DataTypes.TEXT, allowNull: true },
+    contact: { type: DataTypes.JSONB, defaultValue: {} },
+    isActive: { type: DataTypes.BOOLEAN, defaultValue: true }
+  });
+
+  const LeadListing = sequelize.define('LeadListing', {
+    providerId: { type: DataTypes.INTEGER, allowNull: false },
+    name: { type: DataTypes.STRING, allowNull: false },
+    description: { type: DataTypes.TEXT, allowNull: true },
+    pricePerLead: { type: DataTypes.DECIMAL(10, 2), allowNull: false },
+    deliveryMethod: { type: DataTypes.ENUM('csv', 'webhook', 'live_call'), allowNull: false },
+    availableLeads: { type: DataTypes.INTEGER, defaultValue: 0 },
+    isActive: { type: DataTypes.BOOLEAN, defaultValue: true }
+  });
+
+  const LeadOrder = sequelize.define('LeadOrder', {
+    buyerTenantId: { type: DataTypes.STRING, allowNull: false },
+    listingId: { type: DataTypes.INTEGER, allowNull: false },
+    quantity: { type: DataTypes.INTEGER, allowNull: false },
+    pricePerLead: { type: DataTypes.DECIMAL(10, 2), allowNull: false },
+    totalCost: { type: DataTypes.DECIMAL(10, 2), allowNull: false },
+    status: { type: DataTypes.ENUM('pending', 'completed', 'cancelled'), defaultValue: 'pending' }
+  });
+
+  LeadProvider.hasMany(LeadListing, { foreignKey: 'providerId' });
+  LeadListing.belongsTo(LeadProvider, { foreignKey: 'providerId' });
+
+  LeadListing.hasMany(LeadOrder, { foreignKey: 'listingId' });
+  LeadOrder.belongsTo(LeadListing, { foreignKey: 'listingId' });
+
+  return { LeadProvider, LeadListing, LeadOrder };
+};

--- a/shared/marketplace-routes.js
+++ b/shared/marketplace-routes.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const MarketplaceService = require('./marketplace-service');
+
+module.exports = function(app, sequelize, authenticateToken) {
+  const router = express.Router();
+  const models = require('./marketplace-models')(sequelize);
+  const service = new MarketplaceService(models);
+
+  router.post('/marketplace/providers', authenticateToken, async (req, res) => {
+    try {
+      const provider = await service.createProvider(req.user.tenantId, req.body);
+      res.json(provider);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.get('/marketplace/providers', authenticateToken, async (req, res) => {
+    const providers = await service.listProviders();
+    res.json(providers);
+  });
+
+  router.post('/marketplace/listings', authenticateToken, async (req, res) => {
+    try {
+      const listing = await service.createListing(req.body.providerId, req.body);
+      res.json(listing);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.get('/marketplace/listings', authenticateToken, async (req, res) => {
+    const listings = await service.listListings();
+    res.json(listings);
+  });
+
+  router.post('/marketplace/listings/:id/purchase', authenticateToken, async (req, res) => {
+    try {
+      const order = await service.purchaseLeads(req.user.tenantId, req.params.id, req.body.quantity);
+      res.json(order);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.get('/marketplace/orders', authenticateToken, async (req, res) => {
+    const orders = await service.listOrders({ buyerTenantId: req.user.tenantId });
+    res.json(orders);
+  });
+
+  app.use('/api', router);
+  return models;
+};

--- a/shared/marketplace-service.js
+++ b/shared/marketplace-service.js
@@ -1,0 +1,49 @@
+class MarketplaceService {
+  constructor(models) {
+    this.models = models;
+  }
+
+  createProvider(tenantId, data) {
+    return this.models.LeadProvider.create({ ...data, tenantId });
+  }
+
+  listProviders() {
+    return this.models.LeadProvider.findAll({ where: { isActive: true } });
+  }
+
+  createListing(providerId, data) {
+    return this.models.LeadListing.create({ ...data, providerId });
+  }
+
+  listListings() {
+    return this.models.LeadListing.findAll({ where: { isActive: true }, include: this.models.LeadProvider });
+  }
+
+  async purchaseLeads(buyerTenantId, listingId, quantity) {
+    const listing = await this.models.LeadListing.findByPk(listingId);
+    if (!listing || !listing.isActive) throw new Error('Listing not available');
+    if (listing.availableLeads < quantity) throw new Error('Not enough leads');
+
+    const totalCost = parseFloat(listing.pricePerLead) * quantity;
+
+    const order = await this.models.LeadOrder.create({
+      buyerTenantId,
+      listingId,
+      quantity,
+      pricePerLead: listing.pricePerLead,
+      totalCost,
+      status: 'completed'
+    });
+
+    await listing.decrement('availableLeads', { by: quantity });
+    return order;
+  }
+
+  listOrders(filter) {
+    const where = {};
+    if (filter.buyerTenantId) where.buyerTenantId = filter.buyerTenantId;
+    return this.models.LeadOrder.findAll({ where, include: this.models.LeadListing });
+  }
+}
+
+module.exports = MarketplaceService;


### PR DESCRIPTION
## Summary
- add Sequelize models for lead providers, lead listings and orders
- add marketplace service and routes
- initialize marketplace in backend server
- document new marketplace API endpoints

## Testing
- `node -c shared/marketplace-models.js`
- `node -c shared/marketplace-service.js`
- `node -c shared/marketplace-routes.js`
- `node -c backend/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68649fb5a3f48331aa53a601613ec2e1