### PR TITLE
Add marketplace analytics

### DIFF
--- a/docs/marketplace-api.md
+++ b/docs/marketplace-api.md
@@ -41,3 +41,15 @@ Payload:
 
 ## List Orders
 `GET /marketplace/orders`
+
+## Update Order Performance
+`POST /marketplace/orders/:orderId/performance`
+```json
+{
+  "closedLeads": 5
+}
+```
+
+## Provider Analytics
+`GET /marketplace/providers/:providerId/analytics`
+Returns overall close rates and buyer breakdown for a lead provider.

--- a/shared/marketplace-models.js
+++ b/shared/marketplace-models.js
@@ -25,7 +25,9 @@ module.exports = function(sequelize) {
     quantity: { type: DataTypes.INTEGER, allowNull: false },
     pricePerLead: { type: DataTypes.DECIMAL(10, 2), allowNull: false },
     totalCost: { type: DataTypes.DECIMAL(10, 2), allowNull: false },
-    status: { type: DataTypes.ENUM('pending', 'completed', 'cancelled'), defaultValue: 'pending' }
+    status: { type: DataTypes.ENUM('pending', 'completed', 'cancelled'), defaultValue: 'pending' },
+    // Number of leads from this order that were eventually closed by the buyer.
+    closedLeads: { type: DataTypes.INTEGER, defaultValue: 0 }
   });
 
   LeadProvider.hasMany(LeadListing, { foreignKey: 'providerId' });

--- a/shared/marketplace-routes.js
+++ b/shared/marketplace-routes.js
@@ -48,6 +48,26 @@ module.exports = function(app, sequelize, authenticateToken) {
     res.json(orders);
   });
 
+  // Update order performance (e.g. how many leads were closed)
+  router.post('/marketplace/orders/:id/performance', authenticateToken, async (req, res) => {
+    try {
+      const order = await service.updateOrderPerformance(req.params.id, req.body.closedLeads);
+      res.json(order);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  // Get aggregated analytics for a provider
+  router.get('/marketplace/providers/:id/analytics', authenticateToken, async (req, res) => {
+    try {
+      const data = await service.getProviderAnalytics(req.params.id);
+      res.json(data);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
   app.use('/api', router);
   return models;
 };

--- a/shared/marketplace-service.js
+++ b/shared/marketplace-service.js
@@ -44,6 +44,53 @@ class MarketplaceService {
     if (filter.buyerTenantId) where.buyerTenantId = filter.buyerTenantId;
     return this.models.LeadOrder.findAll({ where, include: this.models.LeadListing });
   }
+
+  // Update the performance metrics for an order (e.g. number of closed leads)
+  async updateOrderPerformance(orderId, closedLeads) {
+    const order = await this.models.LeadOrder.findByPk(orderId);
+    if (!order) throw new Error('Order not found');
+    order.closedLeads = closedLeads;
+    await order.save();
+    return order;
+  }
+
+  // Get aggregated analytics for a lead provider across all orders
+  async getProviderAnalytics(providerId) {
+    const listings = await this.models.LeadListing.findAll({
+      where: { providerId },
+      include: this.models.LeadOrder
+    });
+
+    let totalSold = 0;
+    let totalClosed = 0;
+    const buyers = {};
+
+    listings.forEach(listing => {
+      listing.LeadOrders.forEach(order => {
+        totalSold += order.quantity;
+        totalClosed += order.closedLeads;
+        if (!buyers[order.buyerTenantId]) {
+          buyers[order.buyerTenantId] = { sold: 0, closed: 0 };
+        }
+        buyers[order.buyerTenantId].sold += order.quantity;
+        buyers[order.buyerTenantId].closed += order.closedLeads;
+      });
+    });
+
+    const buyerBreakdown = Object.entries(buyers).map(([tenantId, data]) => ({
+      tenantId,
+      leadsPurchased: data.sold,
+      leadsClosed: data.closed,
+      closeRate: data.sold > 0 ? (data.closed / data.sold * 100).toFixed(1) : '0'
+    }));
+
+    return {
+      totalLeadsSold: totalSold,
+      totalLeadsClosed: totalClosed,
+      overallCloseRate: totalSold > 0 ? (totalClosed / totalSold * 100).toFixed(1) : '0',
+      buyers: buyerBreakdown
+    };
+  }
 }
 
 module.exports = MarketplaceService;


### PR DESCRIPTION
## Summary
- add `closedLeads` field to marketplace orders
- support aggregating provider analytics in marketplace service
- expose new routes for updating order performance and provider analytics
- document the added analytics endpoints

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864aa33914c8331b9dfec522139a6cf