### PR TITLE
Implement lead stage management API

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -475,6 +475,11 @@ async function initializeModules() {
   leadRoutes(app, sequelize, authenticateToken);
   console.log('Lead Routes module initialized successfully');
 
+  console.log('Initializing Stage Routes module...');
+  const stageRoutes = require('../shared/stage-routes');
+  stageRoutes(app, sequelize, authenticateToken);
+  console.log('Stage Routes module initialized successfully');
+
   // FIXED: Initialize the Webhook Integration module AFTER optisignsService is available
   console.log('Initializing Webhook Integration module...');
   

--- a/docs/lead-stage-api.md
+++ b/docs/lead-stage-api.md
@@ -1,0 +1,21 @@
+# Lead Stage Management API
+
+These endpoints allow you to manage lead stages and assign stages to contacts. All routes require Bearer authentication and are prefixed with `/api`.
+
+## Stage CRUD
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/stages` | List stages for the current tenant. |
+| `POST` | `/stages` | Create a new stage. Body should include `title` and optional `catalysts`. |
+| `PUT` | `/stages/:id` | Update a stage. |
+| `DELETE` | `/stages/:id` | Remove a stage. |
+
+`catalysts` is a free-form JSON array describing typical triggers that move a lead into the stage. Elements may contain dynamic variables used elsewhere in the system.
+
+## Assigning a Lead Stage
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `PUT` | `/leads/:id/stage` | Set the stage for a single lead. Body: `{ "stageId": 2 }`. |
+

--- a/shared/stage-models.js
+++ b/shared/stage-models.js
@@ -1,0 +1,15 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = function(sequelize) {
+  if (sequelize.models.Stage) {
+    return { Stage: sequelize.models.Stage };
+  }
+
+  const Stage = sequelize.define('Stage', {
+    tenantId: { type: DataTypes.STRING, allowNull: false },
+    title: { type: DataTypes.STRING, allowNull: false },
+    catalysts: { type: DataTypes.JSONB, defaultValue: [] }
+  });
+
+  return { Stage };
+};

--- a/shared/stage-routes.js
+++ b/shared/stage-routes.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const StageService = require('./stage-service');
+const modelsInit = require('./lead-models');
+
+module.exports = function(app, sequelize, authenticateToken) {
+  const router = express.Router();
+  const models = { ...modelsInit(sequelize) };
+  const service = new StageService(models);
+
+  router.post('/stages', authenticateToken, async (req, res) => {
+    try {
+      const stage = await service.createStage(req.user.tenantId, req.body);
+      res.status(201).json(stage);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.get('/stages', authenticateToken, async (req, res) => {
+    try {
+      const stages = await service.listStages(req.user.tenantId);
+      res.json(stages);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.put('/stages/:id', authenticateToken, async (req, res) => {
+    try {
+      const stage = await service.updateStage(req.params.id, req.user.tenantId, req.body);
+      res.json(stage);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.delete('/stages/:id', authenticateToken, async (req, res) => {
+    try {
+      await service.deleteStage(req.params.id, req.user.tenantId);
+      res.json({ success: true });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.put('/leads/:id/stage', authenticateToken, async (req, res) => {
+    try {
+      const lead = await service.assignLeadStage(req.params.id, req.user.tenantId, req.body.stageId);
+      res.json(lead);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  app.use('/api', router);
+  return router;
+};

--- a/shared/stage-service.js
+++ b/shared/stage-service.js
@@ -1,0 +1,40 @@
+class StageService {
+  constructor(models) {
+    this.models = models;
+  }
+
+  async createStage(tenantId, data) {
+    return this.models.Stage.create({ ...data, tenantId });
+  }
+
+  async listStages(tenantId) {
+    return this.models.Stage.findAll({
+      where: { tenantId },
+      order: [['createdAt', 'ASC']]
+    });
+  }
+
+  async updateStage(id, tenantId, data) {
+    const stage = await this.models.Stage.findOne({ where: { id, tenantId } });
+    if (!stage) throw new Error('Stage not found');
+    await stage.update(data);
+    return stage;
+  }
+
+  async deleteStage(id, tenantId) {
+    const stage = await this.models.Stage.findOne({ where: { id, tenantId } });
+    if (!stage) throw new Error('Stage not found');
+    await stage.destroy();
+    return true;
+  }
+
+  async assignLeadStage(leadId, tenantId, stageId) {
+    const lead = await this.models.Lead.findOne({ where: { id: leadId, tenantId } });
+    if (!lead) throw new Error('Lead not found');
+    lead.stageId = stageId;
+    await lead.save();
+    return lead;
+  }
+}
+
+module.exports = StageService;


### PR DESCRIPTION
## Summary
- add Stage model and integrate into Lead
- create StageService and StageRoutes for CRUD and assignment
- initialize stage routes in server
- document API for managing lead stages

## Testing
- `npm test` *(fails: missing script)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6864ce90a5dc8331bc1bf96d9ad57142