### PR TITLE
Integrate marketing service with webhook events

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -571,7 +571,12 @@ async function initializeModules() {
   // Initialize marketing module
   try {
     const initMarketing = require('../shared/marketing-routes');
-    marketingModels = initMarketing(app, sequelize, authenticateToken);
+    marketingModels = initMarketing(
+      app,
+      sequelize,
+      authenticateToken,
+      webhookIntegration?.services?.webhookService
+    );
     console.log('Marketing module initialized successfully');
   } catch (error) {
     console.error('Error initializing marketing module:', error);

--- a/docs/marketing-api.md
+++ b/docs/marketing-api.md
@@ -31,3 +31,14 @@ All routes are mounted under `/api` and require authentication.
 
 ## Get Campaign Metrics
 `GET /marketing/campaigns/:id/metrics`
+
+## Record Lead
+`POST /marketing/campaigns/:id/leads`
+```json
+{
+  "leadId": 42,
+  "externalLeadId": "abc123",
+  "data": { "source": "facebook" }
+}
+```
+Creates a marketing lead entry, attaches marketing info to the lead and triggers a webhook event.


### PR DESCRIPTION
## Summary
- connect marketing module to webhook service when initializing server
- allow passing webhook service into marketing routes and service
- attach marketing info to leads and emit a webhook event when recording a lead
- add API route `/marketing/campaigns/:id/leads`
- document how to record a lead via the marketing API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864dcf3a710833190c33ae166e97ae2