### PR TITLE
Add permissions to user management

### DIFF
--- a/backend/create-tenant.js
+++ b/backend/create-tenant.js
@@ -72,7 +72,8 @@ async function createTenantAndUser() {
       password: hashedPassword,
       email: 'admin@testcompany.com',
       tenantId: savedTenant._id,
-      role: 'admin'
+      role: 'admin',
+      permissions: {}
     });
 
     const savedUser = await user.save();

--- a/backend/server.js
+++ b/backend/server.js
@@ -144,6 +144,10 @@ const User = sequelize.define('User', {
     type: DataTypes.ENUM('admin', 'agent'),
     defaultValue: 'agent'
   },
+  permissions: {
+    type: DataTypes.JSONB,
+    defaultValue: {}
+  },
   firstName: {
     type: DataTypes.STRING,
     allowNull: true

--- a/backend/servssssssser.js
+++ b/backend/servssssssser.js
@@ -55,6 +55,10 @@ const User = sequelize.define('User', {
   role: {
     type: DataTypes.ENUM('admin', 'agent'),
     defaultValue: 'agent'
+  },
+  permissions: {
+    type: DataTypes.JSONB,
+    defaultValue: {}
   }
 });
 
@@ -260,7 +264,8 @@ app.post('/api/register', async (req, res) => {
       password: hashedPassword,
       email,
       tenantId,
-      role
+      role,
+      permissions: {}
     });
     
     res.status(201).json({ message: 'User created successfully' });
@@ -777,7 +782,8 @@ async function startServer() {
         password: hashedPassword,
         email: 'admin@example.com',
         tenantId: tenant.id.toString(),
-        role: 'admin'
+        role: 'admin',
+        permissions: {}
       });
       
       console.log('Default tenant and admin user created successfully');

--- a/backend/verify_database.js
+++ b/backend/verify_database.js
@@ -39,6 +39,10 @@ const User = sequelize.define('User', {
     type: DataTypes.ENUM('admin', 'agent'),
     defaultValue: 'agent'
   },
+  permissions: {
+    type: DataTypes.JSONB,
+    defaultValue: {}
+  },
   firstName: {
     type: DataTypes.STRING(255),
     allowNull: true
@@ -188,7 +192,8 @@ async function verifyAndFixDatabase() {
         role: 'admin',
         firstName: 'System',
         lastName: 'Administrator',
-        isActive: true
+        isActive: true,
+        permissions: {}
       });
       console.log('✅ Admin user created');
     } else {

--- a/shared/auth-routes.js
+++ b/shared/auth-routes.js
@@ -40,7 +40,8 @@ module.exports = function(app, sequelize) {
         role,
         firstName,
         lastName,
-        isActive: true
+        isActive: true,
+        permissions: {}
       });
 
       res.status(201).json({ message: 'User created successfully' });

--- a/shared/user-routes.js
+++ b/shared/user-routes.js
@@ -121,7 +121,7 @@ module.exports = function(app, sequelize, authenticateToken) {
   router.post('/users', authenticateToken, requireAdmin, async (req, res) => {
     try {
       
-      const { username, password, email, role = 'agent' } = req.body;
+      const { username, password, email, role = 'agent', permissions = {} } = req.body;
       const tenantId = req.user.tenantId;
       
       // Validation
@@ -171,6 +171,7 @@ module.exports = function(app, sequelize, authenticateToken) {
         email,
         tenantId,
         role,
+        permissions,
         isActive: true,
         createdBy: req.user.id
       });
@@ -213,7 +214,7 @@ module.exports = function(app, sequelize, authenticateToken) {
         return res.status(404).json({ error: 'User not found' });
       }
       
-      const { email, role, isActive, firstName, lastName, phone, timezone, preferences } = req.body;
+      const { email, role, isActive, firstName, lastName, phone, timezone, preferences, permissions } = req.body;
       const updates = {};
       
       // Email update
@@ -250,6 +251,14 @@ module.exports = function(app, sequelize, authenticateToken) {
         }
         
         updates.role = role;
+      }
+
+      // Permissions update (admin only)
+      if (permissions !== undefined) {
+        if (requesterRole !== 'admin') {
+          return res.status(403).json({ error: 'Only admins can change user permissions' });
+        }
+        updates.permissions = permissions;
       }
       
       // Status update (admin only)

--- a/verify_database.js
+++ b/verify_database.js
@@ -39,6 +39,10 @@ const User = sequelize.define('User', {
     type: DataTypes.ENUM('admin', 'agent'),
     defaultValue: 'agent'
   },
+  permissions: {
+    type: DataTypes.JSONB,
+    defaultValue: {}
+  },
   firstName: {
     type: DataTypes.STRING(255),
     allowNull: true
@@ -188,7 +192,8 @@ async function verifyAndFixDatabase() {
         role: 'admin',
         firstName: 'System',
         lastName: 'Administrator',
-        isActive: true
+        isActive: true,
+        permissions: {}
       });
       console.log('✅ Admin user created');
     } else {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -47,6 +47,10 @@ const User = sequelize.define('User', {
     type: DataTypes.ENUM('admin', 'agent'),
     defaultValue: 'agent'
   },
+  permissions: {
+    type: DataTypes.JSONB,
+    defaultValue: {}
+  },
   firstName: {
     type: DataTypes.STRING,
     allowNull: true


### PR DESCRIPTION
## Summary
- allow admins to specify `permissions` when creating and updating users
- include a new `permissions` JSONB column on the `User` model across server scripts
- default `permissions` to an empty object for new admin accounts and registrations

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68655873fee883318fb528b4fb7898d6