### PR TITLE
Enable ffprobe with fluent-ffmpeg

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
+    "@ffprobe-installer/ffprobe": "^2.1.2",
     "@optisigns/optisigns": "^1.0.2",
     "asterisk-ami-client": "^1.1.5",
     "axios": "^1.10.0",

--- a/shared/content-creation-sdk.js
+++ b/shared/content-creation-sdk.js
@@ -5,6 +5,8 @@ const path = require('path');
 const fs = require('fs').promises;
 const sharp = require('sharp'); // For image processing
 const ffmpeg = require('fluent-ffmpeg'); // For video processing
+const ffprobeInstaller = require('@ffprobe-installer/ffprobe');
+ffmpeg.setFfprobePath(ffprobeInstaller.path);
 const { Op, Sequelize } = require('sequelize');
 
 class ContentCreationSDK {

--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -2,6 +2,8 @@ const path = require('path');
 const fs = require('fs').promises;
 const sharp = require('sharp'); // For image processing
 const ffmpeg = require('fluent-ffmpeg'); // For video processing
+const ffprobeInstaller = require('@ffprobe-installer/ffprobe');
+ffmpeg.setFfprobePath(ffprobeInstaller.path);
 const { Op, Sequelize } = require('sequelize');
 const axios = require('axios');
 const crypto = require('crypto');


### PR DESCRIPTION
## Summary
- bundle ffprobe binary using `@ffprobe-installer/ffprobe`
- configure fluent-ffmpeg to use that binary in the content creation service and SDK

## Testing
- `npm install @ffprobe-installer/ffprobe`
- `npm ls @ffprobe-installer/ffprobe`


------
https://chatgpt.com/codex/tasks/task_e_6865dd3ea7a88331b8bccb146e47fa77