### PR TITLE
Fix ffmpeg availability

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@ffprobe-installer/ffprobe": "^2.1.2",
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@optisigns/optisigns": "^1.0.2",
     "asterisk-ami-client": "^1.1.5",
     "axios": "^1.10.0",

--- a/shared/content-creation-sdk.js
+++ b/shared/content-creation-sdk.js
@@ -6,7 +6,9 @@ const fs = require('fs').promises;
 const sharp = require('sharp'); // For image processing
 const ffmpeg = require('fluent-ffmpeg'); // For video processing
 const ffprobeInstaller = require('@ffprobe-installer/ffprobe');
+const ffmpegInstaller = require('@ffmpeg-installer/ffmpeg');
 ffmpeg.setFfprobePath(ffprobeInstaller.path);
+ffmpeg.setFfmpegPath(ffmpegInstaller.path);
 const { Op, Sequelize } = require('sequelize');
 
 class ContentCreationSDK {

--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -3,7 +3,9 @@ const fs = require('fs').promises;
 const sharp = require('sharp'); // For image processing
 const ffmpeg = require('fluent-ffmpeg'); // For video processing
 const ffprobeInstaller = require('@ffprobe-installer/ffprobe');
+const ffmpegInstaller = require('@ffmpeg-installer/ffmpeg');
 ffmpeg.setFfprobePath(ffprobeInstaller.path);
+ffmpeg.setFfmpegPath(ffmpegInstaller.path);
 const { Op, Sequelize } = require('sequelize');
 const axios = require('axios');
 const crypto = require('crypto');


### PR DESCRIPTION
## Summary
- ensure ffmpeg binary is available via `@ffmpeg-installer`
- configure ffmpeg path in content creation modules

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in frontend *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f3b314f08331af4c6fe7fc69b076