### PR TITLE
Fix ffmpeg availability

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@ffprobe-installer/ffprobe": "^2.1.2",
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@optisigns/optisigns": "^1.0.2",
     "asterisk-ami-client": "^1.1.5",
     "axios": "^1.10.0",

--- a/shared/content-creation-sdk.js
+++ b/shared/content-creation-sdk.js
@@ -6,7 +6,9 @@ const fs = require('fs').promises;
 const sharp = require('sharp'); // For image processing
 const ffmpeg = require('fluent-ffmpeg'); // For video processing
 const ffprobeInstaller = require('@ffprobe-installer/ffprobe');
+const ffmpegInstaller = require('@ffmpeg-installer/ffmpeg');
 ffmpeg.setFfprobePath(ffprobeInstaller.path);
+ffmpeg.setFfmpegPath(ffmpegInstaller.path);
 const { Op, Sequelize } = require('sequelize');
 
 class ContentCreationSDK {

--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -3,7 +3,9 @@ const fs = require('fs').promises;
 const sharp = require('sharp'); // For image processing
 const ffmpeg = require('fluent-ffmpeg'); // For video processing
 const ffprobeInstaller = require('@ffprobe-installer/ffprobe');
+const ffmpegInstaller = require('@ffmpeg-installer/ffmpeg');
 ffmpeg.setFfprobePath(ffprobeInstaller.path);
+ffmpeg.setFfmpegPath(ffmpegInstaller.path);
 const { Op, Sequelize } = require('sequelize');
 const axios = require('axios');
 const crypto = require('crypto');
@@ -1194,7 +1196,7 @@ async createOptiSignsApiGatewayConfig(projectId, tenantId, options = {}) {
       });
       const stream = metadata.streams.find(s => s.width && s.height) || {};
       const dimensions = { width: stream.width || 0, height: stream.height || 0 };
-      const duration = parseFloat(metadata.format.duration || 0);
+      const duration = Math.round(parseFloat(metadata.format.duration || 0));
       const bitrate = parseInt(metadata.format.bit_rate || 0);
       let fps = 0;
       if (stream.avg_frame_rate && stream.avg_frame_rate.includes('/')) {
@@ -1250,7 +1252,7 @@ async createOptiSignsApiGatewayConfig(projectId, tenantId, options = {}) {
           resolve(data);
         });
       });
-      const duration = parseFloat(metadata.format.duration || 0);
+      const duration = Math.round(parseFloat(metadata.format.duration || 0));
       const bitrate = parseInt(metadata.format.bit_rate || 0);
       return { duration, bitrate, waveformUrl: null };
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure ffmpeg binary is available via `@ffmpeg-installer`
- configure ffmpeg path in content creation modules
- round video/audio duration to integer before saving

## Testing
- `npm test` in backend *(fails: Missing script)*
- `npm test` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f3b314f08331af4c6fe7fc69b076