### PR TITLE
Fix token retrieval for auth

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -259,17 +259,34 @@ const {
 
 // JWT Middleware
 const authenticateToken = (req, res, next) => {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
-  
-  if (!token) return res.status(401).json({ error: 'Access denied' });
-  
+  let token = null;
+
+  const authHeader = req.headers['authorization'] || req.headers['Authorization'];
+  if (authHeader) {
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (match) {
+      token = match[1];
+    }
+  }
+
+  if (!token && req.query && req.query.token) {
+    token = req.query.token;
+  }
+
+  if (!token && req.cookies && req.cookies.token) {
+    token = req.cookies.token;
+  }
+
+  if (!token) {
+    return res.status(401).json({ error: 'Access denied. No token provided' });
+  }
+
   try {
     const verified = jwt.verify(token, JWT_SECRET);
     req.user = verified;
-    next();
+    return next();
   } catch (err) {
-    res.status(400).json({ error: 'Invalid token' });
+    return res.status(401).json({ error: 'Invalid token' });
   }
 };
 

--- a/backend/serversy.js
+++ b/backend/serversy.js
@@ -16,17 +16,34 @@ const DID = mongoose.model('DID', didSchema);
 
 // Auth middleware
 const authenticateToken = (req, res, next) => {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
-  
-  if (!token) return res.status(401).json({ error: 'Access denied' });
-  
+  let token = null;
+
+  const authHeader = req.headers['authorization'] || req.headers['Authorization'];
+  if (authHeader) {
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (match) {
+      token = match[1];
+    }
+  }
+
+  if (!token && req.query && req.query.token) {
+    token = req.query.token;
+  }
+
+  if (!token && req.cookies && req.cookies.token) {
+    token = req.cookies.token;
+  }
+
+  if (!token) {
+    return res.status(401).json({ error: 'Access denied. No token provided' });
+  }
+
   try {
     const verified = jwt.verify(token, JWT_SECRET);
     req.user = verified;
-    next();
+    return next();
   } catch (err) {
-    res.status(400).json({ error: 'Invalid token' });
+    return res.status(401).json({ error: 'Invalid token' });
   }
 };
 

--- a/backend/servssssssser.js
+++ b/backend/servssssssser.js
@@ -234,17 +234,34 @@ CallLog.belongsTo(Lead, { foreignKey: 'leadId' });
 
 // Auth middleware
 const authenticateToken = (req, res, next) => {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
-  
-  if (!token) return res.status(401).json({ error: 'Access denied' });
-  
+  let token = null;
+
+  const authHeader = req.headers['authorization'] || req.headers['Authorization'];
+  if (authHeader) {
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (match) {
+      token = match[1];
+    }
+  }
+
+  if (!token && req.query && req.query.token) {
+    token = req.query.token;
+  }
+
+  if (!token && req.cookies && req.cookies.token) {
+    token = req.cookies.token;
+  }
+
+  if (!token) {
+    return res.status(401).json({ error: 'Access denied. No token provided' });
+  }
+
   try {
     const verified = jwt.verify(token, JWT_SECRET);
     req.user = verified;
-    next();
+    return next();
   } catch (err) {
-    res.status(400).json({ error: 'Invalid token' });
+    return res.status(401).json({ error: 'Invalid token' });
   }
 };
 


### PR DESCRIPTION
## Summary
- support header, query and cookie token retrieval in auth middleware
- improve error messages when token missing or invalid

## Testing
- `npm test --silent` *(fails: no test script)*
- `npm run lint --silent` *(fails: missing script)*
- `node --check backend/server.js`
- `node --check backend/servssssssser.js`

------
https://chatgpt.com/codex/tasks/task_e_6866bb1a23fc8331b551fedc3a66fb65