### PR TITLE
Enable CSV bulk upload for sales rep photos

### DIFF
--- a/docs/sales-rep-photo-api.md
+++ b/docs/sales-rep-photo-api.md
@@ -33,6 +33,14 @@ curl -X POST http://localhost:3001/api/sales-rep-photos/upload \
   -F "repName=John Doe"
 ```
 
+Upload many reps at once from a CSV file with `name`, `email` and `photoUrl` columns:
+
+```bash
+curl -X POST http://localhost:3001/api/sales-rep-photos/bulk-csv \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -F "csv=@reps.csv"
+```
+
 ```bash
 curl -X POST http://localhost:3001/api/webhooks/endpoint/YOUR_ENDPOINT_KEY \
   -H "Authorization: Bearer YOUR_WEBHOOK_TOKEN" \


### PR DESCRIPTION
## Summary
- allow CSV uploads for sales rep photos
- retry fallback query in list route when no results
- document the CSV upload API

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6866ccabe41483318211027ffedbe3e6