### PR TITLE
Fix template update handling

### DIFF
--- a/docs/content-creator-api.md
+++ b/docs/content-creator-api.md
@@ -21,6 +21,7 @@ Manage templates for reusable layouts.
 | `GET` | `/api/content/templates` | List templates with optional filters. |
 | `GET` | `/api/content/templates/:templateId` | Retrieve a single template. |
 | `POST` | `/api/content/templates` | Create a new template. |
+| `PUT` | `/api/content/templates/:templateId` | Update an existing template. |
 
 ## Project Endpoints
 Projects contain elements that make up a piece of content.

--- a/shared/content-creation-routes.js
+++ b/shared/content-creation-routes.js
@@ -556,7 +556,7 @@ app.get('/api/content/debug/:exportId', authenticateToken, async (req, res) => {
         req.user.id,
         req.body
       );
-      
+
       res.status(201).json({
         template,
         message: 'Template created successfully',
@@ -564,6 +564,27 @@ app.get('/api/content/debug/:exportId', authenticateToken, async (req, res) => {
       });
     } catch (error) {
       console.error('Error creating template:', error.message);
+      res.status(400).json({ error: error.message });
+    }
+  });
+
+  // Update template
+  app.put('/api/content/templates/:templateId', authenticateToken, async (req, res) => {
+    try {
+      const template = await contentService.updateTemplate(
+        req.params.templateId,
+        req.user.tenantId,
+        req.user.id,
+        req.body
+      );
+
+      res.json({
+        template,
+        message: 'Template updated successfully',
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      console.error('Error updating template:', error.message);
       res.status(400).json({ error: error.message });
     }
   });

--- a/shared/content-creation-sdk.js
+++ b/shared/content-creation-sdk.js
@@ -555,6 +555,28 @@ class ContentCreationSDK {
     }
   }
 
+  async updateTemplate(templateId, tenantId, updateData) {
+    try {
+      const template = await this.models.ContentTemplate.findOne({
+        where: { id: templateId, tenantId }
+      });
+
+      if (!template) {
+        throw new Error('Template not found');
+      }
+
+      await template.update({
+        ...updateData,
+        updatedAt: new Date()
+      });
+
+      this.log(`Template ${templateId} updated for tenant ${tenantId}`);
+      return template;
+    } catch (error) {
+      this.handleError('updateTemplate', error);
+    }
+  }
+
   /**
    * Get templates with filtering
    */

--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -452,6 +452,29 @@ getImageExtension(contentType, url) {
     }
   }
 
+  async updateTemplate(templateId, tenantId, userId, updateData) {
+    try {
+      const template = await this.models.ContentTemplate.findOne({
+        where: { id: templateId, tenantId }
+      });
+
+      if (!template) {
+        throw new Error('Template not found');
+      }
+
+      await template.update({
+        ...updateData,
+        updatedAt: new Date()
+      });
+
+      console.log(`Template "${template.name}" updated for tenant ${tenantId}`);
+      return template;
+    } catch (error) {
+      console.error('Error updating template:', error);
+      throw new Error(`Failed to update template: ${error.message}`);
+    }
+  }
+
 
   // ===== PROJECT MANAGEMENT =====
 


### PR DESCRIPTION
## Summary
- add endpoint for updating templates
- support template updates in the content creation service and SDK
- document the new update endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866e7092bcc8331bce5eae2a8ccc421