### PR TITLE
Fix base URL for video assets

### DIFF
--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -2419,7 +2419,9 @@ async generateProjectImage(project, options = {}) {
           .on('error', reject);
       });
 
-      const baseUrl = process.env.BASE_URL || 'http://localhost:3001';
+      // Use configured BASE_URL for generating links to the video file.
+      // Default to the production server if the environment variable is not set
+      const baseUrl = process.env.BASE_URL || 'http://34.122.156.88:3001';
       const publicUrl = `${baseUrl}/uploads/content/videos/${outputName}`;
 
       return { filePath: outputPath, publicUrl };

--- a/shared/webhook-service.js
+++ b/shared/webhook-service.js
@@ -1002,7 +1002,7 @@ class WebhookService {
         
         let publicUrl = asset.public_url;
         if (!publicUrl && asset.file_path) {
-          const baseUrl = process.env.BASE_URL || 'http://localhost:3001';
+          const baseUrl = process.env.BASE_URL || 'http://34.122.156.88:3001';
           const fileName = path.basename(asset.file_path);
           publicUrl = `${baseUrl}/uploads/content/assets/${fileName}`;
           
@@ -1132,7 +1132,7 @@ class WebhookService {
         
         let publicUrl = asset.public_url;
         if (!publicUrl && asset.file_path) {
-          const baseUrl = process.env.BASE_URL || 'http://localhost:3001';
+          const baseUrl = process.env.BASE_URL || 'http://34.122.156.88:3001';
           const fileName = path.basename(asset.file_path);
           publicUrl = `${baseUrl}/uploads/content/assets/${fileName}`;
           


### PR DESCRIPTION
## Summary
- ensure celebration videos and sales rep assets use correct BASE_URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68670d464cc083318dea7bbcd84c8df1