### PR TITLE
Improve video element playback

### DIFF
--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -1978,12 +1978,14 @@ async generateElementHTML(element, options = {}) {
         const autoplay = (properties.autoplay !== false) ? 'autoplay' : '';
         const loop = (properties.loop !== false) ? 'loop' : '';
         const muted = (properties.muted !== false) ? 'muted' : '';
+        const controls = (properties.controls !== false) ? 'controls' : '';
+        const preload = properties.preload || 'auto';
         const mimeType = this.getVideoMimeType(absoluteVideoUrl);
 
         content = `<video class="element video-element"
                       data-element-id="${elementId}"
                       style="${inlineStyles}"
-                      ${autoplay} ${loop} ${muted}
+                      ${autoplay} ${loop} ${muted} ${controls} preload="${preload}"
                       playsinline>
                         <source src="${absoluteVideoUrl}" type="${mimeType}">
                     </video>`;


### PR DESCRIPTION
## Summary
- enable controls and preload on generated video elements

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6867292177f48331a429ca894fd7bc00