### PR TITLE
Update docs for announcement project endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -31,6 +31,8 @@ Base path: `/api/content`
 
 ### Templates
 
+*Deprecated:* These endpoints remain for legacy integrations but projects are now preferred.
+
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
 | `GET` | `/templates` | List templates. Supports filtering by category, visibility and search. |
@@ -140,4 +142,12 @@ Base path: `/api/optisigns`
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
 | `POST` | `/displays/:id/push` | Push content to a display immediately or by schedule. |
+
+## Announcement Webhooks
+
+Base path: `/api/webhooks/announcement`
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/projects` | List announcement projects created by webhook events. Returns `{ "projects": [], "totalCount": 0 }`. |
 


### PR DESCRIPTION
## Summary
- note that template endpoints are deprecated
- document new `/api/webhooks/announcement/projects` endpoint

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `worker`


------
https://chatgpt.com/codex/tasks/task_e_6868bfad73c08331af38a5ce26811d0d