### PR TITLE
Fix project ID handling in sales rep workflow

### DIFF
--- a/test-sales-rep-photo-workflow.js
+++ b/test-sales-rep-photo-workflow.js
@@ -67,8 +67,9 @@ async function createProject() {
   };
 
   const res = await api.post('/content/projects', projectData);
-  console.log('✅ Project created:', res.data.id);
-  return res.data;
+  const project = res.data.project || res.data;
+  console.log('✅ Project created:', project.id);
+  return project;
 }
 
 async function createWebhook(projectId) {


### PR DESCRIPTION
## Summary
- return the correct project object from `/content/projects` API call in `test-sales-rep-photo-workflow.js`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686951f54c0083318d1e18905c9a9b25