### PR TITLE
Fix project data parsing in sales rep workflow

### DIFF
--- a/test-sales-rep-photo-workflow.js
+++ b/test-sales-rep-photo-workflow.js
@@ -67,8 +67,8 @@ async function createProject() {
   };
 
   const res = await api.post('/content/projects', projectData);
-  console.log('✅ Project created:', res.data.id);
-  return res.data;
+  console.log('✅ Project created:', res.data.project.id);
+  return res.data.project;
 }
 
 async function createWebhook(projectId) {


### PR DESCRIPTION
## Summary
- correct `createProject` response handling
- return the created project directly

## Testing
- `node test-sales-rep-photo-workflow.js` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_686951f54c0083318d1e18905c9a9b25