### PR TITLE
Add announcement API routes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -487,6 +487,20 @@ async function initializeModules() {
     console.error('Error initializing Sales Rep Photo module:', error);
   }
 
+  // Initialize simple Announcement routes
+  try {
+    if (contentService && optisignsService) {
+      console.log('Initializing Announcement routes...');
+      const initAnnouncementRoutes = require('../shared/announcement-routes');
+      initAnnouncementRoutes(app, sequelize, authenticateToken, contentService, optisignsService);
+      console.log('Announcement routes initialized successfully');
+    } else {
+      console.log('Skipping Announcement routes (dependencies missing)');
+    }
+  } catch (error) {
+    console.error('Error initializing Announcement routes:', error);
+  }
+
   // Initialize User Routes
   console.log('Initializing User Routes module...');
   const userRoutes = require('../shared/user-routes');

--- a/docs/API.md
+++ b/docs/API.md
@@ -153,3 +153,20 @@ Base path: `/api/webhooks/announcement`
 | ------ | -------- | ----------- |
 | `GET` | `/projects` | List announcement projects created by webhook events. Returns `{ "projects": [], "totalCount": 0 }`. |
 
+## Simple Announcement Endpoints
+
+These routes provide a quick way to publish an announcement using a sales rep photo.
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/announcement/video` | Generate a short video with the sales rep photo and push it to the given displays. |
+| `POST` | `/announcement/image` | Push the sales rep photo as an image to the given displays. |
+
+Both endpoints accept a JSON body with:
+
+- `repEmail` (required) – email used to locate the sales rep photo.
+- `repName` (optional) – name shown on the video.
+- `dealAmount` (optional) – amount text for the video endpoint.
+- `companyName` (optional) – company name for the video endpoint.
+- `displayIds` (required) – one or more OptiSigns display IDs.
+

--- a/shared/announcement-routes.js
+++ b/shared/announcement-routes.js
@@ -1,0 +1,95 @@
+const express = require('express');
+const fs = require('fs').promises;
+
+module.exports = function(app, sequelize, authenticateToken, contentService, optisignsService) {
+  const router = express.Router();
+  const { ContentAsset } = sequelize.models;
+  const { Op } = sequelize.Sequelize;
+
+  async function findRepPhoto(tenantId, email) {
+    const lowerEmail = email.toLowerCase();
+    return await ContentAsset.findOne({
+      where: {
+        tenantId: tenantId.toString(),
+        categories: { [Op.overlap]: ['Sales Reps', 'sales_reps'] },
+        [Op.or]: [
+          sequelize.where(sequelize.fn('LOWER', sequelize.col("metadata->>'repEmail'")), lowerEmail),
+          sequelize.where(sequelize.fn('LOWER', sequelize.col("metadata->>'rep_email'")), lowerEmail),
+          sequelize.where(sequelize.fn('LOWER', sequelize.col("metadata->>'email'")), lowerEmail)
+        ]
+      },
+      order: [['created_at', 'DESC']]
+    });
+  }
+
+  router.post('/announcement/video', authenticateToken, async (req, res) => {
+    try {
+      const { repEmail, repName, dealAmount = '', companyName = '', displayIds } = req.body;
+      if (!repEmail || !displayIds) {
+        return res.status(400).json({ error: 'repEmail and displayIds are required' });
+      }
+      const ids = Array.isArray(displayIds) ? displayIds : [displayIds];
+      const tenantId = req.user.tenantId;
+      const repPhoto = await findRepPhoto(tenantId, repEmail);
+      if (!repPhoto) {
+        return res.status(404).json({ error: 'Sales rep photo not found' });
+      }
+      const videoInfo = await contentService.generateCelebrationVideo({
+        repName: repName || repPhoto.metadata?.repName || repEmail,
+        repPhotoUrl: repPhoto.publicUrl,
+        dealAmount,
+        companyName
+      });
+      const buffer = await fs.readFile(videoInfo.filePath);
+      const uploaded = await optisignsService.uploadContent(
+        tenantId,
+        buffer,
+        `celebration-${Date.now()}`,
+        'celebration.mp4',
+        { contentType: 'video/mp4' }
+      );
+      const pushResults = await optisignsService.pushContentToMultipleDevices(
+        tenantId,
+        ids,
+        uploaded.id
+      );
+      res.json({ success: true, assetId: uploaded.id, pushResults });
+    } catch (error) {
+      console.error('Announcement video error:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  router.post('/announcement/image', authenticateToken, async (req, res) => {
+    try {
+      const { repEmail, repName, displayIds } = req.body;
+      if (!repEmail || !displayIds) {
+        return res.status(400).json({ error: 'repEmail and displayIds are required' });
+      }
+      const ids = Array.isArray(displayIds) ? displayIds : [displayIds];
+      const tenantId = req.user.tenantId;
+      const repPhoto = await findRepPhoto(tenantId, repEmail);
+      if (!repPhoto) {
+        return res.status(404).json({ error: 'Sales rep photo not found' });
+      }
+      const buffer = await fs.readFile(repPhoto.filePath);
+      const uploaded = await optisignsService.uploadImageContent(
+        tenantId,
+        buffer,
+        `rep-image-${Date.now()}`,
+        { fileName: 'rep.png', contentType: repPhoto.mimeType || 'image/png' }
+      );
+      const pushResults = await optisignsService.pushContentToMultipleDevices(
+        tenantId,
+        ids,
+        uploaded.id
+      );
+      res.json({ success: true, assetId: uploaded.id, pushResults });
+    } catch (error) {
+      console.error('Announcement image error:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  app.use('/api', router);
+};


### PR DESCRIPTION
## Summary
- add new announcement routes for video or image announcements
- hook announcement routes into server
- document announcement endpoints

## Testing
- `node --check shared/announcement-routes.js`

------
https://chatgpt.com/codex/tasks/task_e_686965a055a08331965207f0354d976a