### PR TITLE
Fix categories type mismatch in sales rep photo lookup

### DIFF
--- a/shared/announcement-routes.js
+++ b/shared/announcement-routes.js
@@ -11,7 +11,13 @@ module.exports = function(app, sequelize, authenticateToken, contentService, opt
     return await ContentAsset.findOne({
       where: {
         tenantId: tenantId.toString(),
-        categories: { [Op.overlap]: ['Sales Reps', 'sales_reps'] },
+        // Cast categories to text[] so overlap works regardless of column type
+        [Op.and]: [
+          sequelize.where(
+            sequelize.cast(sequelize.col('categories'), 'text[]'),
+            { [Op.overlap]: ['Sales Reps', 'sales_reps'] }
+          )
+        ],
         [Op.or]: [
           sequelize.where(sequelize.fn('LOWER', sequelize.col("metadata->>'repEmail'")), lowerEmail),
           sequelize.where(sequelize.fn('LOWER', sequelize.col("metadata->>'rep_email'")), lowerEmail),

--- a/shared/content-creation-models.js
+++ b/shared/content-creation-models.js
@@ -640,7 +640,8 @@ elementType: {
       defaultValue: []
     },
     categories: {
-      type: DataTypes.ARRAY(DataTypes.STRING),
+      // Use TEXT[] to avoid type mismatches when querying
+      type: DataTypes.ARRAY(DataTypes.TEXT),
       defaultValue: []
     },
     isPublic: {

--- a/shared/webhook-service.js
+++ b/shared/webhook-service.js
@@ -989,13 +989,13 @@ class WebhookService {
             OR LOWER(metadata->>'salesRepEmail') = $2
           )
           AND (
-            categories @> ARRAY['Sales Reps']::text[]
-            OR categories @> ARRAY['sales_reps']::text[]
-            OR categories @> ARRAY['sales-reps']::text[]
-            OR categories @> ARRAY['Sales Rep']::text[]
-            OR categories @> ARRAY['sales_rep']::text[]
-            OR categories @> ARRAY['salesrep']::text[]
-            OR categories @> ARRAY['SalesRep']::text[]
+            categories::text[] @> ARRAY['Sales Reps']::text[]
+            OR categories::text[] @> ARRAY['sales_reps']::text[]
+            OR categories::text[] @> ARRAY['sales-reps']::text[]
+            OR categories::text[] @> ARRAY['Sales Rep']::text[]
+            OR categories::text[] @> ARRAY['sales_rep']::text[]
+            OR categories::text[] @> ARRAY['salesrep']::text[]
+            OR categories::text[] @> ARRAY['SalesRep']::text[]
           )
         ORDER BY created_at DESC 
         LIMIT 1
@@ -1048,15 +1048,15 @@ class WebhookService {
             metadata->>'email' as email,
             categories
           FROM content_assets 
-          WHERE 
+          WHERE
             tenant_id = $1
             AND processing_status = 'completed'
             AND (
-              categories @> ARRAY['Sales Reps']::text[]
-              OR categories @> ARRAY['sales_reps']::text[]
-              OR categories @> ARRAY['sales-reps']::text[]
-              OR categories @> ARRAY['Sales Rep']::text[]
-              OR categories @> ARRAY['sales_rep']::text[]
+              categories::text[] @> ARRAY['Sales Reps']::text[]
+              OR categories::text[] @> ARRAY['sales_reps']::text[]
+              OR categories::text[] @> ARRAY['sales-reps']::text[]
+              OR categories::text[] @> ARRAY['Sales Rep']::text[]
+              OR categories::text[] @> ARRAY['sales_rep']::text[]
             )
           ORDER BY created_at DESC 
           LIMIT 10


### PR DESCRIPTION
## Summary
- store `categories` as `TEXT[]` in content asset models
- cast `categories` to `text[]` when searching for sales rep photos
- fix overlap query in announcement route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68697f4541288331af09f025aff922e9