### PR TITLE
Fix query type errors in sales rep asset lookups

### DIFF
--- a/shared/sales-rep-photo-routes.js
+++ b/shared/sales-rep-photo-routes.js
@@ -103,7 +103,7 @@ async function findSalesRepAsset(ContentAsset, sequelize, whereConditions) {
   const rawQuery = `
     SELECT * FROM content_assets 
     WHERE (
-      (categories @> ARRAY['Sales Reps']::text[] OR categories @> ARRAY['sales_reps']::text[])
+      (categories::text[] @> ARRAY['Sales Reps']::text[] OR categories::text[] @> ARRAY['sales_reps']::text[])
       OR 
       (LOWER(categories::text) LIKE '%sales rep%' OR LOWER(categories::text) LIKE '%sales_rep%')
     )
@@ -170,7 +170,7 @@ async function findAllSalesRepAssets(ContentAsset, sequelize, whereConditions, o
   const rawQuery = `
     SELECT * FROM content_assets
     WHERE (
-      (categories @> ARRAY['Sales Reps']::text[] OR categories @> ARRAY['sales_reps']::text[])
+      (categories::text[] @> ARRAY['Sales Reps']::text[] OR categories::text[] @> ARRAY['sales_reps']::text[])
       OR
       (LOWER(categories::text) LIKE '%sales rep%' OR LOWER(categories::text) LIKE '%sales_rep%')
     )
@@ -271,7 +271,7 @@ async function countSalesRepAssets(ContentAsset, sequelize, whereConditions, opt
   const rawQuery = `
     SELECT COUNT(*) as count FROM content_assets 
     WHERE (
-      (categories @> ARRAY['Sales Reps']::text[] OR categories @> ARRAY['sales_reps']::text[])
+      (categories::text[] @> ARRAY['Sales Reps']::text[] OR categories::text[] @> ARRAY['sales_reps']::text[])
       OR 
       (LOWER(categories::text) LIKE '%sales rep%' OR LOWER(categories::text) LIKE '%sales_rep%')
     )
@@ -285,8 +285,9 @@ async function countSalesRepAssets(ContentAsset, sequelize, whereConditions, opt
     )
   `;
 
+  const searchParam = `%${search.toLowerCase()}%`;
+
   try {
-    const searchParam = `%${search.toLowerCase()}%`;
     const [results] = await sequelize.query(rawQuery, {
       bind: [tenantId, searchParam],
       type: sequelize.QueryTypes.SELECT


### PR DESCRIPTION
## Summary
- handle varchar[] categories columns by casting to `text[]`
- move `searchParam` outside of try/catch so fallback queries work

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_686985874b248331ba26e9d25ec8202c