### PR TITLE
Improve content project lookup fallback

### DIFF
--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -610,6 +610,21 @@ getImageExtension(contentType, url) {
         });
       }
 
+      // Additional fallback: if projectId looks like a name instead of UUID
+      if (!project) {
+        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!uuidRegex.test(String(projectId))) {
+          const nameQuery = {
+            where: { name: projectId },
+            include: query.include
+          };
+          if (tenantId) {
+            nameQuery.where.tenantId = tenantId;
+          }
+          project = await this.models.ContentProject.findOne(nameQuery);
+        }
+      }
+
       if (!project) {
         throw new Error('Project not found');
       }


### PR DESCRIPTION
## Summary
- enhance `getProjectWithElements` to fall back to name-based lookup when ID lookup fails

## Testing
- `npm -s run test` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6869a0a15f40833182f2d02decaee2cd