### PR TITLE
Align data schemas and photo directories

### DIFF
--- a/docs/content-creator-api.md
+++ b/docs/content-creator-api.md
@@ -2,6 +2,21 @@
 
 This document describes the HTTP endpoints exposed by the Content Creation service. All authenticated routes require a valid JWT via the `Authorization: Bearer <token>` header.
 
+### Common Object Format
+Both templates and projects use a unified JSON shape. Key fields include:
+
+```json
+{
+  "id": "uuid",
+  "tenantId": "string",
+  "name": "string",
+  "description": "string",
+  "canvasSize": {"width": 1920, "height": 1080},
+  "projectData": {},
+  "variables": {}
+}
+```
+
 ## Public OptiSync Endpoints
 These endpoints are primarily used by OptiSigns to pull content from the system.
 

--- a/docs/data-schemas.md
+++ b/docs/data-schemas.md
@@ -1,0 +1,38 @@
+# Common Data Schemas
+
+The services in this repository expose similar JSON objects for OptiSigns displays,
+content templates, projects and sales representative photos. All properties use
+`camelCase` naming to keep the APIs consistent.
+
+## Display
+```json
+{
+  "id": "uuid",
+  "tenantId": "string",
+  "optisignsDisplayId": "string",
+  "name": "string",
+  "uuid": "string",
+  "location": "string",
+  "status": "string",
+  "isActive": true,
+  "isOnline": true
+}
+```
+
+## Template / Project
+```json
+{
+  "id": "uuid",
+  "tenantId": "string",
+  "name": "string",
+  "description": "string",
+  "canvasSize": {"width": 1920, "height": 1080},
+  "projectData": {},
+  "variables": {}
+}
+```
+
+## Sales Rep Photo Asset
+Uploaded photos are treated as normal content assets. The original file is kept
+in `uploads/content/sales-rep-photos` while thumbnails and previews are stored in
+`uploads/content/sales-rep-thumbnails` and `uploads/content/sales-rep-previews`.

--- a/docs/optisigns-service-api.md
+++ b/docs/optisigns-service-api.md
@@ -25,6 +25,23 @@ These endpoints integrate with the OptiSigns digital signage platform. All route
 | `GET` | `/optisigns/takeovers` | List active takeovers. |
 | `POST` | `/optisigns/displays/:id/push` | Push content to a display. |
 
+### Display JSON Format
+All services expose displays using the same camelCase schema:
+
+```json
+{
+  "id": "uuid",
+  "tenantId": "string",
+  "optisignsDisplayId": "string",
+  "name": "string",
+  "uuid": "string",
+  "location": "string",
+  "status": "string",
+  "isActive": true,
+  "isOnline": true
+}
+```
+
 ## Assets
 | Method | Path | Description |
 | ------ | ---- | ----------- |

--- a/docs/sales-rep-photo-api.md
+++ b/docs/sales-rep-photo-api.md
@@ -7,6 +7,8 @@ Only one photo is stored per sales representative. Uploading a new photo for the
 When using the Content Creator, you can place a photo on the canvas by adding an element with `elementType: "sales_rep_photo"`. The element automatically binds to the `{rep_photo}` variable so that the correct representative's image is displayed when a deal is closed.
 You can upload photos one at a time using `/sales-rep-photos/upload` or upload many using a CSV at `/sales-rep-photos/bulk-csv`.
 
+Uploaded files are stored in `uploads/content/sales-rep-photos` with other content assets. Thumbnails are copied to `uploads/content/sales-rep-thumbnails` and previews to `uploads/content/sales-rep-previews` for consistency across services.
+
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | `POST` | `/sales-rep-photos/upload` | Upload a photo for a single sales rep. Form fields: `photo`, `repEmail`, optional `repName`. |

--- a/shared/content-creation-models.js
+++ b/shared/content-creation-models.js
@@ -35,6 +35,7 @@ module.exports = function(sequelize, DataTypes) {
         'media_showcase',
         'social_display',
         'analytics_dashboard',
+        'quick',
         'custom'
       ),
       defaultValue: 'custom'

--- a/shared/content-creation-sdk.js
+++ b/shared/content-creation-sdk.js
@@ -90,7 +90,7 @@ class ContentCreationSDK {
         name: projectData.name,
         description: projectData.description || '',
         templateId: projectData.templateId,
-        canvasSettings: projectData.canvasSettings || {
+        canvasSize: projectData.canvasSize || {
           width: 1920,
           height: 1080,
           backgroundColor: '#ffffff',
@@ -176,7 +176,7 @@ class ContentCreationSDK {
       }
 
       // Increment version on significant changes
-      if (updateData.canvasSettings || updateData.elements) {
+      if (updateData.canvasSize || updateData.elements) {
         updateData.version = (project.version || 1) + 1;
       }
 
@@ -540,7 +540,7 @@ class ContentCreationSDK {
         name: templateData.name,
         description: templateData.description || '',
         category: templateData.category || 'custom',
-        canvasSettings: templateData.canvasSettings || {},
+        canvasSize: templateData.canvasSize || {},
         elements: templateData.elements || [],
         variables: templateData.variables || {},
         metadata: templateData.metadata || {},
@@ -705,7 +705,7 @@ class ContentCreationSDK {
         project: {
           id: project.id,
           name: project.name,
-          canvasSettings: project.canvasSettings
+          canvasSize: project.canvasSize
         },
         elements: project.elements.map(element => ({
           id: element.id,

--- a/shared/content-creation-service.js
+++ b/shared/content-creation-service.js
@@ -43,7 +43,9 @@ class ContentCreationService {
       downloaded: path.join(this.uploadPath, 'downloaded'), // for downloaded external images
       videos: path.join(this.uploadPath, 'videos'), // generated announcement videos
       salesRepThumbnails: path.join(this.uploadPath, 'sales-rep-thumbnails'),
-      salesRepPreviews: path.join(this.uploadPath, 'sales-rep-previews')
+      salesRepPreviews: path.join(this.uploadPath, 'sales-rep-previews'),
+      // Directory to keep the original uploaded photos for reps
+      salesRepPhotos: path.join(this.uploadPath, 'sales-rep-photos')
     };
 
     // Ensure all directories exist on initialization
@@ -739,6 +741,16 @@ async getTemplate(templateId, tenantId) {
         throw new Error('Project not found');
       }
 
+      // Support legacy snake_case or type field
+      const resolvedType =
+        elementData.elementType ||
+        elementData.element_type ||
+        elementData.type;
+      if (!resolvedType) {
+        throw new Error('elementType is required');
+      }
+      elementData.elementType = resolvedType;
+
       // NEW: Download external images immediately when creating image elements
       if ((elementData.elementType === 'image' || elementData.elementType === 'standard_photo' || elementData.elementType === 'sales_rep_photo') && elementData.properties) {
         const imageUrl = elementData.properties.imageUrl || 
@@ -817,6 +829,14 @@ async getTemplate(templateId, tenantId) {
 
       if (!element) {
         throw new Error('Element not found');
+      }
+
+      // Resolve element type in update payload for compatibility
+      if (updateData.element_type && !updateData.elementType) {
+        updateData.elementType = updateData.element_type;
+      }
+      if (updateData.type && !updateData.elementType) {
+        updateData.elementType = updateData.type;
       }
 
       // NEW: Download external images when updating image elements

--- a/shared/sales-rep-photo-routes.js
+++ b/shared/sales-rep-photo-routes.js
@@ -418,6 +418,12 @@ module.exports = function(app, sequelize, authenticateToken, contentService) {
         metadata
       );
 
+      const repPhotoDir = contentService.directories.salesRepPhotos;
+      await fs.mkdir(repPhotoDir, { recursive: true });
+      const origName = path.basename(asset.filePath);
+      const origDest = path.join(repPhotoDir, origName);
+      await fs.copyFile(asset.filePath, origDest);
+
       // Copy thumbnails to sales rep specific directories
       try {
         const thumbName = path.basename(asset.thumbnailUrl || '');
@@ -442,9 +448,10 @@ module.exports = function(app, sequelize, authenticateToken, contentService) {
           newPreviews[size] = `${req.protocol}://${req.get('host')}/uploads/content/sales-rep-previews/${name}`;
         }
 
-        await asset.update({ 
-          thumbnailUrl: asset.thumbnailUrl, 
-          previewUrls: newPreviews 
+
+        await asset.update({
+          thumbnailUrl: asset.thumbnailUrl,
+          previewUrls: newPreviews
         });
 
         console.log('✅ Asset uploaded with thumbnails:', {
@@ -548,6 +555,12 @@ module.exports = function(app, sequelize, authenticateToken, contentService) {
               await fs.copyFile(src, dest);
               newPreviews[size] = `${req.protocol}://${req.get('host')}/uploads/content/sales-rep-previews/${namePart}`;
             }
+
+            const repPhotoDir = contentService.directories.salesRepPhotos;
+            await fs.mkdir(repPhotoDir, { recursive: true });
+            const origName = path.basename(asset.filePath);
+            const origDest = path.join(repPhotoDir, origName);
+            await fs.copyFile(asset.filePath, origDest);
 
             await asset.update({ thumbnailUrl: asset.thumbnailUrl, previewUrls: newPreviews });
           } catch (thumbErr) {
@@ -759,6 +772,12 @@ router.get('/sales-rep-photos', authenticateToken, async (req, res) => {
         req.file,
         metadata
       );
+
+      const repPhotoDir = contentService.directories.salesRepPhotos;
+      await fs.mkdir(repPhotoDir, { recursive: true });
+      const origName = path.basename(asset.filePath);
+      const origDest = path.join(repPhotoDir, origName);
+      await fs.copyFile(asset.filePath, origDest);
 
       res.json({
         message: 'Fallback photo set successfully',


### PR DESCRIPTION
## Summary
- document common data schemas for displays, templates, projects and sales rep photos
- reference unified schemas in API docs
- store original sales rep photos under `sales-rep-photos` directory
- fix schema naming in Content Creation SDK
- validate element types and support legacy names
- allow `quick` template category

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ad021966c83319c133c206025a90c